### PR TITLE
Mask api keys in settings

### DIFF
--- a/web/scanEngine/forms.py
+++ b/web/scanEngine/forms.py
@@ -367,7 +367,7 @@ class HackeroneForm(forms.ModelForm):
 
     username = forms.CharField(
         required=True,
-        widget=forms.TextInput(
+        widget=forms.PasswordInput(
             attrs={
                 "class": "form-control form-control-lg",
                 "id": "username",
@@ -376,7 +376,7 @@ class HackeroneForm(forms.ModelForm):
 
     api_key = forms.CharField(
         required=True,
-        widget=forms.TextInput(
+        widget=forms.PasswordInput(
             attrs={
                 "class": "form-control form-control-lg",
                 "id": "api_key",

--- a/web/scanEngine/templates/scanEngine/settings/api.html
+++ b/web/scanEngine/templates/scanEngine/settings/api.html
@@ -44,11 +44,16 @@ API Vault
               <div class="mb-3">
                 <label for="key_netlas" class="form-label">Netlas</label>
                 <p class="text-muted">Netlas keys will be used to get whois information and other OSINT data.</p>
+                <div class="input-group input-group-merge">
                 {% if netlas_key %}
-                  <input class="form-control" type="text" id="key_netlas" name="key_netlas" placeholder="Enter Netlas Key" value="{{netlas_key}}">
+                  <input class="form-control" type="password" id="key_netlas" name="key_netlas" placeholder="Enter Netlas Key" value="{{netlas_key}}" >
                 {% else %}
-                  <input class="form-control" type="text" id="key_netlas" name="key_netlas" placeholder="Enter Netlas Key">
+                  <input class="form-control" type="password" id="key_netlas" name="key_netlas" placeholder="Enter Netlas Key">
                 {% endif %}
+                  <div class="input-group-text" data-password="false">
+                    <span class="password-eye"></span>
+                  </div>
+                </div>
                 <span class="text-muted float-end">This is optional</span>
               </div>
               <div class="mb-0">

--- a/web/scanEngine/templates/scanEngine/settings/api.html
+++ b/web/scanEngine/templates/scanEngine/settings/api.html
@@ -29,11 +29,16 @@ API Vault
               <div class="mb-3">
                 <label for="key_openai" class="form-label">OpenAI <span class="ms-1 badge bg-soft-danger text-danger">🔥 Recommended</span><span class="ms-1 badge bg-soft-primary text-primary">Experimental</span></label>
                 <p class="text-muted">OpenAI keys will be used to generate vulnerability description, remediation, impact and vulnerability report writing using ChatGPT.</p>
+                <div class="input-group input-group-merge">
                 {% if openai_key %}
-                  <input class="form-control" type="text" id="key_openai" name="key_openai" placeholder="Enter OpenAI Key" value="{{openai_key}}">
+                  <input class="form-control" type="password" id="key_openai" name="key_openai" placeholder="Enter OpenAI Key" value="{{openai_key}}">
                 {% else %}
-                  <input class="form-control" type="text" id="key_openai" name="key_openai" placeholder="Enter OpenAI Key">
+                  <input class="form-control" type="password" id="key_openai" name="key_openai" placeholder="Enter OpenAI Key" >
                 {% endif %}
+                  <div class="input-group-text" data-password="false">
+                    <span class="password-eye"></span>
+                  </div>
+                </div>
                 <span class="text-muted float-end">This is optional but recommended.</span>
               </div>
               <div class="mb-3">

--- a/web/scanEngine/templates/scanEngine/settings/hackerone.html
+++ b/web/scanEngine/templates/scanEngine/settings/hackerone.html
@@ -47,7 +47,12 @@ HackerOne Settings
             </div>
             <div class="col-xl-6 col-lg-6 col-md-6 col-sm-12 col-12">
               <label for="hackerone_api_token" class="form-label">Generate your <a href="https://hackerone.com/settings/api_token/edit" target="_blank">API Token from here <i class="fe-external-link"></i></a></label>
-              {{form.api_key}}
+              <div class="input-group input-group-merge">
+                  {{form.api_key}}
+                  <div class="input-group-text" data-password="false">
+                    <span class="password-eye"></span>
+                  </div>
+              </div>
             </div>
           </div>
           <a class="btn btn-primary float-end mt-3" href="javascript:test_hackerone()" role="button">


### PR DESCRIPTION
## I was able to add a button to hide API Key, responding to issue  #57 
### I was able to do so by refactoring / reusing HTML code from the loggin page, <br> and It works as following :
 

- API Keys are hidden by default (input type password)
- you can click on the button to show them (Will trigger JS function to change the type to text and the eye icon)

### I have integrated this feature in API Vault and HackerOne Views in Settings as shown in the screenshots bellow :

#### API Vault :
<img width="1273" alt="image" src="https://github.com/Security-Tools-Alliance/rengine-ng/assets/63622641/e7294d60-f4c7-4a37-8715-425082fb4349">

#### Hackerone : 
<img width="1273" alt="image" src="https://github.com/Security-Tools-Alliance/rengine-ng/assets/63622641/f50ff2b5-bdd1-477b-b9c6-941c0417c858">


### _Please keep in mind that I am not a hunter and I don't use RENGINE on daily bases, testing this feature would be appreciated_

### Thanks in advance 🥇 
