### PR TITLE
fix(file_fuzz): subdomain_id key error

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1730,7 +1730,7 @@ def dir_file_fuzz(self, ctx={}, description=None):
 			dirscan.save()
 
 			# Get subdomain and add dirscan
-			if ctx['subdomain_id'] > 0:
+			if ctx.get('subdomain_id') and ctx['subdomain_id'] > 0:
 				subdomain = Subdomain.objects.get(id=ctx['subdomain_id'])
 			else:
 				subdomain_name = get_subdomain_from_url(endpoint.http_url)


### PR DESCRIPTION
fix #17 

Problem comes when a file fuzzing was launched on the target (scan) and not on the subdomain (subscan).
subdomain_var does not exists while launching a scan from a target so a simple existence check resolve the problem and the subdomain is extracted from the endpoint

tested and working