### PR TITLE
fix(security): rework scan working folder location to prevent leaks

### DIFF
--- a/web/reNgine/settings.py
+++ b/web/reNgine/settings.py
@@ -13,7 +13,7 @@ mimetypes.add_type("text/css", ".css", True)
 
 # Root env vars
 RENGINE_HOME = os.environ.get('RENGINE_HOME', '/usr/src/app')
-RENGINE_RESULTS = os.environ.get('RENGINE_RESULTS', f'{RENGINE_HOME}/scan_results')
+RENGINE_RESULTS = os.environ.get('RENGINE_RESULTS', f'/usr/src/scan_results')
 RENGINE_CACHE_ENABLED = bool(int(os.environ.get('RENGINE_CACHE_ENABLED', '0')))
 RENGINE_RECORD_ENABLED = bool(int(os.environ.get('RENGINE_RECORD_ENABLED', '1')))
 RENGINE_RAISE_ON_ERROR = bool(int(os.environ.get('RENGINE_RAISE_ON_ERROR', '0')))

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -11,6 +11,7 @@ import yaml
 import tldextract
 import concurrent.futures
 import base64
+import uuid
 
 from datetime import datetime
 from urllib.parse import urlparse
@@ -104,7 +105,8 @@ def initiate_scan(
 	scan.domain = domain
 	scan.start_scan_date = timezone.now()
 	scan.tasks = engine.tasks
-	scan.results_dir = f'{results_dir}/{domain.name}_{scan.id}'
+	uuid_scan = uuid.uuid1()
+	scan.results_dir = f'{results_dir}/{domain.name}/scans/{uuid_scan}'
 	add_gf_patterns = gf_patterns and 'fetch_url' in engine.tasks
 	if add_gf_patterns:
 		scan.used_gf_patterns = ','.join(gf_patterns)
@@ -249,7 +251,8 @@ def initiate_subscan(
 	config = yaml.safe_load(engine.yaml_configuration)
 
 	# Create results directory
-	results_dir = f'{scan.results_dir}/subscans/{subscan.id}'
+	uuid_scan = uuid.uuid1()
+	results_dir = f'{scan.results_dir}/{domain.name}/subscans/{uuid_scan}'
 	os.makedirs(results_dir, exist_ok=True)
 
 	# Run task

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -250,7 +250,8 @@ def list_target(request, slug):
 def delete_target(request, id):
     obj = get_object_or_404(Domain, id=id)
     if request.method == "POST":
-        run_command(f'rm -rf {settings.RENGINE_RESULTS}/scan_results/{obj.name}*')
+        run_command(f'rm -rf {settings.RENGINE_RESULTS}/{obj.name}')
+        run_command(f'rm -rf {settings.RENGINE_RESULTS}/{obj.name}*') # for backward compatibility
         obj.delete()
         responseData = {'status': 'true'}
         messages.add_message(

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -250,7 +250,7 @@ def list_target(request, slug):
 def delete_target(request, id):
     obj = get_object_or_404(Domain, id=id)
     if request.method == "POST":
-        run_command(f'rm -rf {settings.TOOL_LOCATION} scan_results/{obj.name}*')
+        run_command(f'rm -rf {settings.RENGINE_RESULTS}/scan_results/{obj.name}*')
         obj.delete()
         responseData = {'status': 'true'}
         messages.add_message(


### PR DESCRIPTION
fix #16 

Replace the `scan_id` sequential number by an `uuid`, hard to guess.
This quickly address the issue while we could think about a better solution when we will work on the #71 

I've also "normalize" the path :
```mermaid
graph LR;
    A(/usr/src/scan_results)
    B(/domain_name)
    C(/subscans)
    D(/scans)
    E(/uuid)
    A-->B;
    B-->C;
    B-->D;
    C-->E;
    D-->E;
```

![image](https://github.com/Security-Tools-Alliance/rengine-ng/assets/1230954/7bf345a3-b71f-4e8b-aa59-ccc4ad257d5c)

![image](https://github.com/Security-Tools-Alliance/rengine-ng/assets/1230954/b7af314e-c68e-4913-9520-f4488960ce67)

Tested and working