### PR TITLE
fix(scan): rework the alive endpoint and redirection operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ reNgine-ng is not an ordinary reconnaissance suite; it's a game-changer! We've t
 
 🦾&nbsp;&nbsp; reNgine-ng has advanced reconnaissance capabilities, harnessing a range of open-source tools to deliver a comprehensive web application reconnaissance experience. With it's intuitive User Interface, it excels in subdomain discovery, pinpointing IP addresses and open ports, collecting endpoints, conducting directory and file fuzzing, capturing screenshots, and performing vulnerability scans. To summarize, it does end-to-end reconnaissance. With WHOIS identification and WAF detection, it offers deep insights into target domains. Additionally, reNgine-ng also identifies misconfigured S3 buckets and find interesting subdomains and URLS, based on specific keywords to helps you identify your next target, making it an go to tool for efficient reconnaissance.
 
-🗃️&nbsp; &nbsp; Say goodbye to recon data chaos! reNgine-ng seamlessly integrates with a database, providing you with unmatched data correlation and organization. Forgot the hassle of grepping through json, txt or csv files. Plus, our custom query language lets you filter reconnaissance data effortlessly using natural language like operators such as filtering all alive subdomains with `http_status=200` and also filter all subdomains that are alive and has admin in name `http_status=200&name=admin`
+🗃️&nbsp; &nbsp; Say goodbye to recon data chaos! reNgine-ng seamlessly integrates with a database, providing you with unmatched data correlation and organization. Forgot the hassle of grepping through json, txt or csv files. Plus, our custom query language lets you filter reconnaissance data effortlessly using natural language like operators such as filtering all alive subdomains with `http_status>0` and also filter all subdomains that are alive and has admin in name `http_status>0&name=admin`
 
 🔧&nbsp;&nbsp; reNgine-ng offers unparalleled flexibility through its highly configurable scan engines, based on a YAML-based configuration. It offers the freedom to create and customize recon scan engines based on any kind of requirement, users can tailor them to their specific objectives and preferences, from thread management to timeout settings and rate-limit configurations, everything is customizable. Additionally, reNgine-ng offers a range of pre-configured scan engines right out of the box, including Full Scan, Passive Scan, Screenshot Gathering, and the OSINT Scan Engine. These ready-to-use engines eliminate the need for extensive manual setup, aligning perfectly with reNgine-ng's core mission of simplifying the reconnaissance process and enabling users to effortlessly access the right reconnaissance data with minimal effort.
 
@@ -190,7 +190,7 @@ subdomain_discovery: {
 http_crawl: {
   # 'custom_header': 'Cookie: Test',
   # 'threads': 30,
-  # 'follow_redirect': true
+  # 'follow_redirect': false
 }
 port_scan: {
   'enable_http_crawl': true,

--- a/default_yaml_config.yaml
+++ b/default_yaml_config.yaml
@@ -29,7 +29,7 @@ http_crawl: {
   #   'User-Agent': 'Mozilla/5.0'
   # },
   # 'threads': 30,
-  # 'follow_redirect': true
+  # 'follow_redirect': false
 }
 port_scan: {
   'enable_http_crawl': true,

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -49,7 +49,7 @@ def index(request, slug):
     subdomain_count = subdomains.count()
     subdomain_with_ip_count = subdomains.filter(ip_addresses__isnull=False).count()
     alive_count = subdomains.exclude(http_status__exact=0).count()
-    endpoint_alive_count = endpoints.filter(http_status__exact=200).count()
+    endpoint_alive_count = endpoints.filter(http_status__gt=0).count()
 
     info_count = vulnerabilities.filter(severity=0).count()
     low_count = vulnerabilities.filter(severity=1).count()

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -153,20 +153,7 @@ def initiate_scan(
 		is_default=True,
 		subdomain=subdomain
 	)
-	if endpoint and endpoint.is_alive:
-		# TODO: add `root_endpoint` property to subdomain and simply do
-		# subdomain.root_endpoint = endpoint instead
-		logger.warning(f'Found subdomain root HTTP URL {endpoint.http_url}')
-		subdomain.http_url = endpoint.http_url
-		subdomain.http_status = endpoint.http_status
-		subdomain.response_time = endpoint.response_time
-		subdomain.page_title = endpoint.page_title
-		subdomain.content_type = endpoint.content_type
-		subdomain.content_length = endpoint.content_length
-		for tech in endpoint.techs.all():
-			subdomain.technologies.add(tech)
-		subdomain.save()
-
+	save_subdomain_metadata(subdomain, endpoint)
 
 	# Build Celery tasks, crafted according to the dependency graph below:
 	# subdomain_discovery --> port_scan --> fetch_url --> dir_file_fuzz
@@ -281,28 +268,6 @@ def initiate_subscan(
 		'results_dir': results_dir,
 		'url_filter': url_filter
 	}
-
-	# Create initial endpoints in DB: find domain HTTP endpoint so that HTTP
-	# crawling can start somewhere
-	base_url = f'{subdomain.name}{url_filter}' if url_filter else subdomain.name
-	endpoint, _ = save_endpoint(
-		base_url,
-		crawl=enable_http_crawl,
-		ctx=ctx,
-		subdomain=subdomain)
-	if endpoint and endpoint.is_alive:
-		# TODO: add `root_endpoint` property to subdomain and simply do
-		# subdomain.root_endpoint = endpoint instead
-		logger.warning(f'Found subdomain root HTTP URL {endpoint.http_url}')
-		subdomain.http_url = endpoint.http_url
-		subdomain.http_status = endpoint.http_status
-		subdomain.response_time = endpoint.response_time
-		subdomain.page_title = endpoint.page_title
-		subdomain.content_type = endpoint.content_type
-		subdomain.content_length = endpoint.content_length
-		for tech in endpoint.techs.all():
-			subdomain.technologies.add(tech)
-		subdomain.save()
 
 	# Build header + callback
 	workflow = method.si(ctx=ctx)
@@ -559,10 +524,21 @@ def subdomain_discovery(
 	if enable_http_crawl:
 		ctx['track'] = True
 		http_crawl(urls, ctx=ctx, is_ran_from_subdomain_scan=True)
-
-	# Find root subdomain endpoints
-	for subdomain in subdomains:
-		pass
+	else:
+		url_filter = ctx.get('url_filter')
+		enable_http_crawl = config.get(ENABLE_HTTP_CRAWL, DEFAULT_ENABLE_HTTP_CRAWL)
+		# Find root subdomain endpoints
+		for subdomain in subdomains:
+			subdomain_name = subdomain.strip()
+			# Create base endpoint (for scan)
+			http_url = f'{subdomain.name}{url_filter}' if url_filter else subdomain.name
+			endpoint, _ = save_endpoint(
+				http_url,
+				ctx=ctx,
+				is_default=True,
+				subdomain=subdomain
+			)
+			save_subdomain_metadata(subdomain, endpoint)
 
 	# Send notifications
 	subdomains_str = '\n'.join([f'• `{subdomain.name}`' for subdomain in subdomains])
@@ -2075,12 +2051,15 @@ def nuclei_individual_severity_module(self, cmd, severity, enable_http_crawl, sh
 		http_url = sanitize_url(line.get('matched-at'))
 		subdomain_name = get_subdomain_from_url(http_url)
 
-		# TODO: this should be get only
-		subdomain, _ = Subdomain.objects.get_or_create(
-			name=subdomain_name,
-			scan_history=self.scan,
-			target_domain=self.domain
-		)
+		try:
+			subdomain = Subdomain.objects.get(
+				name=subdomain_name,
+				scan_history=self.scan,
+				target_domain=self.domain
+			)
+		except:
+			logger.warning(f'Subdomain {subdomain_name} was not found in the db, skipping vulnerability scan.')
+			continue
 
 		# Look for duplicate vulnerabilities by excluding records that might change but are irrelevant.
 		object_comparison_exclude = ['response', 'curl_command', 'tags', 'references', 'cve_ids', 'cwe_ids']
@@ -2744,7 +2723,7 @@ def http_crawl(
 	if custom_header:
 		custom_header = generate_header_param(custom_header, 'common')
 	threads = config.get(THREADS, DEFAULT_THREADS)
-	follow_redirect = config.get(FOLLOW_REDIRECT, True)
+	follow_redirect = config.get(FOLLOW_REDIRECT, False)
 	self.output_path = None
 	input_path = f'{self.results_dir}/httpx_input.txt'
 	history_file = f'{self.results_dir}/commands.txt'
@@ -2805,7 +2784,7 @@ def http_crawl(
 		host = line.get('host', '')
 		content_length = line.get('content_length', 0)
 		http_status = line.get('status_code')
-		http_url, is_redirect = extract_httpx_url(line)
+		http_url, is_redirect = extract_httpx_url(line, follow_redirect)
 		page_title = line.get('title')
 		webserver = line.get('webserver')
 		cdn = line.get('cdn', False)
@@ -4235,9 +4214,8 @@ def process_httpx_response(line):
 	"""TODO: implement this"""
 
 
-def extract_httpx_url(line):
-	"""Extract final URL from httpx results. Always follow redirects to find
-	the last URL.
+def extract_httpx_url(line, follow_redirect):
+	"""Extract final URL from httpx results.
 
 	Args:
 		line (dict): URL data output by httpx.
@@ -4249,24 +4227,27 @@ def extract_httpx_url(line):
 	final_url = line.get('final_url')
 	location = line.get('location')
 	chain_status_codes = line.get('chain_status_codes', [])
+	http_url = line.get('url')
 
-	# Final URL is already looking nice, if it exists return it
-	if final_url:
+	# Final URL is already looking nice, if it exists and follow redirect is enabled, return it
+	if final_url and follow_redirect:
 		return final_url, False
-	http_url = line['url'] # fallback to url field
 
-	# Handle redirects manually
-	REDIRECT_STATUS_CODES = [301, 302]
-	is_redirect = (
-		status_code in REDIRECT_STATUS_CODES
-		or
-		any(x in REDIRECT_STATUS_CODES for x in chain_status_codes)
-	)
-	if is_redirect and location:
-		if location.startswith(('http', 'https')):
-			http_url = location
-		else:
-			http_url = f'{http_url}/{location.lstrip("/")}'
+	# Handle redirects manually if follow redirect is enabled
+	if follow_redirect:
+		REDIRECT_STATUS_CODES = [301, 302]
+		is_redirect = (
+			status_code in REDIRECT_STATUS_CODES
+			or
+			any(x in REDIRECT_STATUS_CODES for x in chain_status_codes)
+		)
+		if is_redirect and location:
+			if location.startswith(('http', 'https')):
+				http_url = location
+			else:
+				http_url = f'{http_url}/{location.lstrip("/")}'
+	else:
+		is_redirect = False
 
 	# Sanitize URL
 	http_url = sanitize_url(http_url)
@@ -4494,7 +4475,6 @@ def save_endpoint(
 		ctx['track'] = False
 		results = http_crawl(
 			urls=[http_url],
-			method='HEAD',
 			ctx=ctx)
 		if results:
 			endpoint_data = results[0]
@@ -4590,6 +4570,18 @@ def save_subdomain(subdomain_name, ctx={}):
 		subdomain.save()
 	return subdomain, created
 
+def save_subdomain_metadata(subdomain, endpoint):
+	if endpoint and endpoint.is_alive:
+		logger.info(f'Saving HTTP metadatas from {endpoint.http_url}')
+		subdomain.http_url = endpoint.http_url
+		subdomain.http_status = endpoint.http_status
+		subdomain.response_time = endpoint.response_time
+		subdomain.page_title = endpoint.page_title
+		subdomain.content_type = endpoint.content_type
+		subdomain.content_length = endpoint.content_length
+		for tech in endpoint.techs.all():
+			subdomain.technologies.add(tech)
+		subdomain.save()	
 
 def save_email(email_address, scan_history=None):
 	if not validators.email(email_address):
@@ -4674,12 +4666,26 @@ def save_imported_subdomains(subdomains, ctx={}):
 
 	logger.warning(f'Found {len(subdomains)} imported subdomains.')
 	with open(f'{results_dir}/from_imported.txt', 'w+') as output_file:
-		for name in subdomains:
-			subdomain_name = name.strip()
+		url_filter = ctx.get('url_filter')
+		enable_http_crawl = ctx.get('yaml_configuration').get(ENABLE_HTTP_CRAWL, DEFAULT_ENABLE_HTTP_CRAWL)
+		for subdomain in subdomains:
+			# Save valid imported subdomains
+			subdomain_name = subdomain.strip()
 			subdomain, _ = save_subdomain(subdomain_name, ctx=ctx)
 			subdomain.is_imported_subdomain = True
 			subdomain.save()
 			output_file.write(f'{subdomain}\n')
+
+			# Create base endpoint (for scan)
+			http_url = f'{subdomain.name}{url_filter}' if url_filter else subdomain.name
+			endpoint, _ = save_endpoint(
+				http_url,
+				ctx=ctx,
+				crawl=enable_http_crawl,
+				is_default=True,
+				subdomain=subdomain
+			)
+			save_subdomain_metadata(subdomain, endpoint)
 
 
 @app.task(name='query_reverse_whois', bind=False, queue='query_reverse_whois_queue')

--- a/web/startScan/models.py
+++ b/web/startScan/models.py
@@ -372,7 +372,7 @@ class EndPoint(models.Model):
 
 	@hybrid_property
 	def is_alive(self):
-		return self.http_status and (0 < self.http_status < 500) and self.http_status != 404
+		return self.http_status
 
 
 class VulnerabilityTags(models.Model):

--- a/web/startScan/static/startScan/js/detail_scan.js
+++ b/web/startScan/static/startScan/js/detail_scan.js
@@ -7,7 +7,6 @@ function get_ips_from_port(port_number, history_id){
 }
 
 function get_ports_for_ip(ip, history_id){
-	console.log(ip, history_id);
 	document.getElementById("detailScanModalLabel").innerHTML='Open Ports identified for ' + ip;
 	var port_badge = '';
 	fetch('../ip/ports/'+ip+'/'+history_id+'/')
@@ -694,10 +693,8 @@ function get_screenshot(scan_id){
 		var gridzyInstance = document.querySelector('.gridzySkinBlank').gridzy;
 		$('#http_select_filter, #ips_select_filter, #services_select_filter, #ports_select_filter, #tech_select_filter').on('change', function() {
 			values = $(this).val();
-			console.log(values);
 			if(values.length && this.id == 'ips_select_filter'){
 				var replaces_str = values.map(function(values){return values.replace(/(?<=\..*)\./g, '_');});
-				console.log(replaces_str);
 				gridzyInstance.setOptions({
 					filter: replaces_str
 				});
@@ -920,7 +917,6 @@ function get_vulnerability_modal(scan_id=null, severity=null, subdomain_id=null,
 			'Content-Type': 'application/json'
 		},
 	}).then(response => response.json()).then(function(response) {
-		console.log(response);
 		swal.close();
 		$('#xl-modal_title').html(`${subdomain_name}`);
 		render_vulnerability_in_xl_modal(response['count'], subdomain_name, response['results'])
@@ -960,7 +956,6 @@ function get_endpoint_modal(project, scan_id, subdomain_id, subdomain_name){
 			'Content-Type': 'application/json'
 		},
 	}).then(response => response.json()).then(function(response) {
-		console.log(response);
 		swal.close();
 		$('#xl-modal_title').html(`${subdomain_name}`);
 		render_endpoint_in_xlmodal(response['count'], subdomain_name, response['results'])
@@ -999,7 +994,6 @@ function get_directory_modal(scan_id=null, subdomain_id=null, subdomain_name=nul
 			'Content-Type': 'application/json'
 		},
 	}).then(response => response.json()).then(function(response) {
-		console.log(response);
 		swal.close();
 		$('#xl-modal_title').html(`${subdomain_name}`);
 		render_directories_in_xl_modal(response['count'], subdomain_name, response['results'])
@@ -1052,7 +1046,6 @@ function get_logs_modal(scan_id=null, activity_id=null) {
 	fetch(url)
 	.then(response => response.json())
 	.then(data => {
-		console.log(data);
 		swal.close();
 		$('#xl-modal_title').html(`Logs for scan #${scan_history_id}`);
 		data.results.forEach(log => {
@@ -1112,7 +1105,6 @@ $(".add-scan-history-todo").click(function(){
 		body: JSON.stringify(data)
 	}).then(res => res.json())
 	.then(function (response) {
-		console.log(response);
 		if (response.status) {
 			Snackbar.show({
 				text: 'Todo Added.',
@@ -1132,7 +1124,6 @@ $(".add-scan-history-todo").click(function(){
 
 
 function add_note_for_subdomain(subdomain_id, subdomain_name){
-	console.log(subdomain_name);
 	$('#todo-modal-subdomain-name').html(subdomain_name);
 	$("#subdomainTodoTitle").val('');
 	$("#subdomainTodoDescription").val('');
@@ -1452,7 +1443,6 @@ function initiate_subscan(subdomain_ids){
 			tasks.push(this.id)
 		}
 	})
-	console.log(tasks)
 	if (tasks.length === 0) {
 		Swal.fire({
 			title: 'Oops!',
@@ -1526,17 +1516,11 @@ function load_engine_tasks(engine_name){
 	var tasks = []
 	var html = ''
 	var url = `/api/listEngines/?format=json`;
-	console.log(url);
 	$.getJSON(url, function(data) {
-		console.log(data);
 		var engines = data.engines
-		console.log(engines);
-		console.log(engine_name);
 		$.each(engines, function(i, engine){
-			console.log(`${engine.engine_name} == ${engine_name}`)
 			if (engine.engine_name === engine_name){
 				tasks = engine.tasks
-				console.log(tasks)
 			}
 		})
 		$.each(tasks, function(i, task){
@@ -1548,7 +1532,6 @@ function load_engine_tasks(engine_name){
 				</div>
 			</div>`
 		});
-		console.log(html)
 		$('#engineTasks').html(html);
 	})
 }

--- a/web/startScan/views.py
+++ b/web/startScan/views.py
@@ -114,7 +114,7 @@ def detail_scan(request, id, slug):
         subdomains
         .values('name')
         .distinct()
-        .filter(http_status__exact=200)
+        .filter(http_status__gt=0)
         .count()
     )
     important_count = (
@@ -134,7 +134,7 @@ def detail_scan(request, id, slug):
     )
     endpoint_alive_count = (
         endpoints
-        .filter(http_status__exact=200) # TODO: use is_alive() func as it's more precise
+        .filter(http_status__gt=0) # TODO: use is_alive() func as it's more precise
         .values('http_url')
         .distinct()
         .count()
@@ -216,7 +216,7 @@ def detail_scan(request, id, slug):
 def all_subdomains(request, slug):
     subdomains = Subdomain.objects.filter(target_domain__project__slug=slug)
     scan_engines = EngineType.objects.order_by('engine_name').all()
-    alive_subdomains = subdomains.filter(http_status__exact=200) # TODO: replace this with is_alive() function
+    alive_subdomains = subdomains.filter(http_status__gt=0) # TODO: replace this with is_alive() function
     important_subdomains = (
         subdomains
         .filter(is_important=True)
@@ -895,7 +895,7 @@ def create_report(request, id):
         .filter(scan_history__id=id)
         .values('name')
         .distinct()
-        .filter(http_status__exact=200)
+        .filter(http_status__gt=0)
         .count()
     )
     interesting_subdomains = get_interesting_subdomains(scan_history=id)

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -341,7 +341,7 @@ def target_summary(request, slug, id):
         .distinct()
     )
     context['subdomain_count'] = subdomains.count()
-    context['alive_count'] = subdomains.filter(http_status__exact=200).count()
+    context['alive_count'] = subdomains.filter(http_status__gt=0).count()
 
     # Endpoints
     endpoints = (
@@ -351,7 +351,7 @@ def target_summary(request, slug, id):
         .distinct()
     )
     context['endpoint_count'] = endpoints.count()
-    context['endpoint_alive_count'] = endpoints.filter(http_status__exact=200).count()
+    context['endpoint_alive_count'] = endpoints.filter(http_status__gt=0).count()
 
     # Vulnerabilities
     vulnerabilities = Vulnerability.objects.filter(target_domain__id=id)


### PR DESCRIPTION
Fix #7 #14 

With this PR **reNgine-ng** scans will work really better.
Check the issues for more details about the bug.

Now an endpoint is considered as alive **if an HTTP status code exists and is > 0**.
This prevent a lot of problems while running scan because in the current state if an endpoint returns **40x** or **50x** code, **it will not be scanned**.
This modification also correctly set the `is_default` state of the root endpoint of the subdomain that is the base of all the active scan (ffuf, nuclei ...)

There's also a problem with 301 and 302 status code.
In **reNgine-ng**, **HTTPx** was set to follow redirect by default, this creates bugs of scan not launched because the URL of the redirection is not the same as the scanned URL.
So I've switched the default value to **False**. To follow redirections, you must use the `--follow-redirection` parameter in your **http_crawl** section of your **scanEngine** configuration.

I've fixed also small bugs that I've found while testing all the scanEngine concerned by this PR:
- Removed console.log dump that eat CPU in front because they are huge and contains recursive values
- Fix unintended subdomain creation while Nuclei is running

Tested in all target and subdomain scan.