### PR TITLE
fix(ui): escape vulnerability request/response in db and display in ui

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -21,7 +21,7 @@ from celery.result import allow_join_result
 from celery.utils.log import get_task_logger
 from django.db.models import Count
 from dotted_dict import DottedDict
-from django.utils import timezone
+from django.utils import timezone, html
 from pycvesearch import CVESearch
 from metafinder.extractor import extract_metadata_from_google_search
 
@@ -3502,8 +3502,8 @@ def parse_nuclei_result(line):
 		'description': line['info'].get('description', ''),
 		'matcher_name': line.get('matcher-name', ''),
 		'curl_command': line.get('curl-command'),
-		'request': line.get('request'),
-		'response': line.get('response'),
+		'request': html.escape(line.get('request')),
+		'response': html.escape(line.get('response')),
 		'extracted_results': line.get('extracted-results', []),
 		'cvss_metrics': line['info'].get('classification', {}).get('cvss-metrics', ''),
 		'cvss_score': line['info'].get('classification', {}).get('cvss-score'),

--- a/web/static/custom/custom.js
+++ b/web/static/custom/custom.js
@@ -3250,9 +3250,3 @@ function convertToCamelCase(inputString) {
 
 	return camelCaseString;
 }
-
-// Function to unescape HTML special characters
-function unescapeHtml(escapedString) {
-    var doc = new DOMParser().parseFromString(escapedString, "text/html");
-    return doc.documentElement.textContent;
-}

--- a/web/static/custom/custom.js
+++ b/web/static/custom/custom.js
@@ -3002,11 +3002,6 @@ function render_vuln_offcanvas(vuln){
 	var http_request = vuln.request ? vuln.request : '';
 	var http_response = vuln.response ? vuln.response : '';
 
-	http_request = http_request.replace(new RegExp('\r?\n','g'), '<br />');
-	http_response = htmlEncode(http_response);
-
-	http_response = http_response.replace(new RegExp('&#13;&#10;','g'), '<br />');
-
 	body += `<div class="accordion custom-accordion mt-2">
 	<h5 class="m-0 position-relative">
 	<a class="custom-accordion-title text-reset d-block"
@@ -3017,7 +3012,7 @@ function render_vuln_offcanvas(vuln){
 	</a>
 	</h5>
 	<div id="request" class="collapse mt-2">
-	<code>${http_request}</code>
+	<pre>${http_request}</pre>
 	</div>
 	</div>`;
 
@@ -3031,7 +3026,7 @@ function render_vuln_offcanvas(vuln){
 	</a>
 	</h5>
 	<div id="response" class="collapse mt-2">
-	<code>${http_response}</code>
+	<pre>${http_response}</pre>
 	</div>
 	</div>`;
 
@@ -3254,4 +3249,10 @@ function convertToCamelCase(inputString) {
 	const camelCaseString = words.map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 
 	return camelCaseString;
+}
+
+// Function to unescape HTML special characters
+function unescapeHtml(escapedString) {
+    var doc = new DOMParser().parseFromString(escapedString, "text/html");
+    return doc.documentElement.textContent;
 }


### PR DESCRIPTION
Fix #117 

Request/response values are escaped before adding to the db and displayed in a <pre> in the UI

Testes and working using the payload given in the issue