### PR TITLE
build(ci): build docker images for each tag, release, push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,93 @@
 name: Docker Image CI
 
 on:
+  pull_request:
   push:
     branches:
-      - master
+      - "master"
+      - "release/**"
+    tags:
+      - "v*.*.*"
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: security-tools-alliance
+  PROJECT: rengine-ng
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        image: [celery, web, postgres, redis, ollama, certs, proxy]
     steps:
-      - name: Checkout the repo
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Log in to GitHub's Container Registry
-        run: echo "${{ secrets.CONTAINER_REGISTRY_SECRET }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PROJECT }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build the Docker image
-        run: docker build . -t ghcr.io/Security-Tools-Alliance/rengine-ng:latest
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/${{ matrix.image }}
+          file: ./docker/${{ matrix.image }}/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Push the Docker image
-        run: docker push ghcr.io/Security-Tools-Alliance/rengine-ng:latest
+  update-release:
+    needs: build-and-push
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Update release description
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_id=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/latest" | \
+            jq -r .id)
+          
+          images="celery web postgres redis ollama certs proxy"
+          image_list=""
+          for image in $images; do
+            image_list="${image_list}- ghcr.io/${{ env.OWNER }}/${{ env.PROJECT }}:rengine-${image}-${{ github.ref_name }}\n"
+          done
+          
+          body="Docker images for this release:\n${image_list}"
+          
+          curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/${release_id}" \
+            -d "{\"body\": \"$body\"}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ env:
   REGISTRY: ghcr.io
   OWNER: security-tools-alliance
   PROJECT: rengine-ng
+  BOT_NAME: rengine-ci-bot
 
 jobs:
   build-and-push:
@@ -51,8 +52,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.BOT_NAME }}
+          password: ${{ secrets.ORG_GHCR_PAT }}
       
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,21 @@ on:
       - "v*.*.*"
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to registry'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
 
 env:
   REGISTRY: ghcr.io
   OWNER: security-tools-alliance
   PROJECT: rengine-ng
-  BOT_NAME: rengine-ci-bot
 
 jobs:
   build-and-push:
@@ -49,22 +58,33 @@ jobs:
         uses: docker/setup-buildx-action@v3
       
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || github.event.inputs.push_image == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ env.BOT_NAME }}
-          password: ${{ secrets.ORG_GHCR_PAT }}
+          username: ${{ vars.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
       
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: ./docker/${{ matrix.image }}
           file: ./docker/${{ matrix.image }}/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' || github.event.inputs.push_image == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platform }}
+          outputs: type=docker,dest=/tmp/image.tar
+
+      - name: Push image if exists
+        if: github.event.inputs.push_image == 'true'
+        run: |
+          if [ -f /tmp/image.tar ]; then
+            docker load --input /tmp/image.tar
+            docker push ${{ steps.meta.outputs.tags }}
+          else
+            echo "No image found to push"
+          fi
 
   update-release:
     needs: build-and-push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         image: [celery, web, postgres, redis, ollama, certs, proxy]
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -63,6 +64,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platform }}
 
   update-release:
     needs: build-and-push

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,6 @@
         {
             "label": "Build All Docker Images",
             "type": "shell",
-            "command": "echo Building all images with version ${input:globalVersion}",
             "dependsOn": [
                 "Build CELERY",
                 "Build WEB",
@@ -32,7 +31,6 @@
         {
             "label": "Build and Push All Docker Images",
             "type": "shell",
-            "command": "echo Building and pushing all images with version ${input:globalVersion}",
             "dependsOn": [
                 "Build and Push CELERY",
                 "Build and Push WEB",
@@ -150,7 +148,7 @@
         {
             "id": "isLatest",
             "type": "pickString",
-            "description": "Is this the latest version? (This will also push the 'latest' tag)",
+            "description": "Is this the latest version (this will also push the 'latest' tag)?",
             "options": ["true", "false"],
             "default": "false"
           }    ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "Build and Push Docker Image",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-${image}-${version} -f ./${image}/Dockerfile ./${image} && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-${image}-${version}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-${image}-${version} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-${image}-latest -f ./${image}/Dockerfile ./${image} && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-${image}-${version} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-${image}-latest; fi",
             "problemMatcher": [],
             "options": {
               "env": {
@@ -30,45 +30,103 @@
             "problemMatcher": []
         },
         {
+            "label": "Build and Push All Docker Images",
+            "type": "shell",
+            "command": "echo Building and pushing all images with version ${input:globalVersion}",
+            "dependsOn": [
+                "Build and Push CELERY",
+                "Build and Push WEB",
+                "Build and Push POSTGRES",
+                "Build and Push REDIS",
+                "Build and Push OLLAMA",
+                "Build and Push CERTS",
+                "Build and Push PROXY"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": []
+        },
+        {
             "label": "Build CELERY",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-${input:globalVersion} -f ./celery/Dockerfile ./celery && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-latest -f ./celery/Dockerfile ./celery",
             "problemMatcher": []
         },
         {
             "label": "Build WEB",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-web-${input:globalVersion} -f ./web/Dockerfile ./web && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-web-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-web-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-web-latest -f ./web/Dockerfile ./web",
             "problemMatcher": []
         },
         {
             "label": "Build POSTGRES",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-${input:globalVersion} -f ./postgres/Dockerfile ./postgres && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-latest -f ./postgres/Dockerfile ./postgres",
             "problemMatcher": []
         },
         {
             "label": "Build REDIS",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-${input:globalVersion} -f ./redis/Dockerfile ./redis && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-latest -f ./redis/Dockerfile ./redis",
             "problemMatcher": []
         },
         {
             "label": "Build OLLAMA",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-${input:globalVersion} -f ./ollama/Dockerfile ./ollama && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-latest -f ./ollama/Dockerfile ./ollama",
             "problemMatcher": []
         },
         {
             "label": "Build CERTS",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-${input:globalVersion} -f ./certs/Dockerfile ./certs && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-latest -f ./certs/Dockerfile ./certs",
             "problemMatcher": []
         },
         {
             "label": "Build PROXY",
             "type": "shell",
-            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-${input:globalVersion} -f ./proxy/Dockerfile ./proxy && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-${input:globalVersion}",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-latest -f ./proxy/Dockerfile ./proxy",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push CELERY",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-latest -f ./celery/Dockerfile ./celery && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-celery-latest; fi",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push WEB",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-web-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-web-latest -f ./web/Dockerfile ./web && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-web-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-web-latest; fi",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push POSTGRES",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-latest -f ./postgres/Dockerfile ./postgres && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-postgres-latest; fi",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push REDIS",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-latest -f ./redis/Dockerfile ./redis && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-redis-latest; fi",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push OLLAMA",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-latest -f ./ollama/Dockerfile ./ollama && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-ollama-latest; fi",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push CERTS",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-latest -f ./certs/Dockerfile ./certs && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-certs-latest; fi",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build and Push PROXY",
+            "type": "shell",
+            "command": "cd ./docker; docker buildx build -t ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-${input:globalVersion} -t ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-latest -f ./proxy/Dockerfile ./proxy && docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-${input:globalVersion} && if [ \"${input:isLatest}\" = \"true\" ]; then docker push ghcr.io/security-tools-alliance/rengine-ng:rengine-proxy-latest; fi",
             "problemMatcher": []
         }
     ],
@@ -88,6 +146,12 @@
           "type": "pickString",
           "description": "Select the image to build",
           "options": ["celery", "web", "postgres", "redis", "ollama", "certs", "proxy"]
-        }
-    ]
+        },
+        {
+            "id": "isLatest",
+            "type": "pickString",
+            "description": "Is this the latest version? (This will also push the 'latest' tag)",
+            "options": ["true", "false"],
+            "default": "false"
+          }    ]
 }


### PR DESCRIPTION
Fix #106

First PoC to automate docker images creation
This need tests

Here are the main modifications and their explanations:

1. I added triggers for pull requests, pushes to `master` and `release/**`, tags `v*.*.*`, and published releases.

2. I defined environment variables for the registry, owner, and project name to facilitate maintenance.

3. I used a matrix to build all images defined in `tasks.json`.

4. I modified the `docker/metadata-action` configuration to generate appropriate tags, including the `latest` tag for the default branch.

5. I adjusted the context and Dockerfile path in `docker/build-push-action` to match your project structure.

6. I added an `update-release` job that runs only when a release is published. This job updates the release description with the list of Docker images built.

This configuration will automatically build and push all images to GHCR for each pull request (without pushing), each push to `master` and `release/**`, each `v*.*.*` tag, and each published release. The images will be tagged with the version number, commit SHA, and `latest` for the default branch.

Remember to grant the necessary permissions to the GitHub action to push to GHCR and update releases. You can do this in your GitHub repository settings.