### PR TITLE
build(ci): add write permissions

### DIFF
--- a/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
+++ b/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
@@ -9,6 +9,8 @@ jobs:
   close-related-issues:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.ref, 'refs/heads/release/')
+    permissions:
+      issues: write
     steps:
       - name: Extract issue number
         id: extract_issue_number


### PR DESCRIPTION
This should fix the following CI error:

```
shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    ISSUE_NUMBER: 139
    GH_TOKEN: ***
GraphQL: Resource not accessible by integration (addComment)
Error: Process completed with exit code 1.
```