### PR TITLE
fix(install): revert changes of prebuilt chain

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,11 +85,11 @@ if [ $isNonInteractive = false ]; then
           INSTALL_TYPE="source"
           ;;
       2|"")
-          INSTALL_TYPE="pre-built"
+          INSTALL_TYPE="prebuilt"
           ;;
       *)
           log "Invalid choice. Defaulting to pre-built images." $COLOR_YELLOW
-          INSTALL_TYPE="pre-built"
+          INSTALL_TYPE="prebuilt"
           ;;
   esac
 


### PR DESCRIPTION
We need to revert the value, it creates problem when installing
![image](https://github.com/user-attachments/assets/04ee28da-9259-4974-9633-e703548cb725)

This should be merged ASAP