### PR TITLE
build(images): restrict image creation, add correct tags and clean non tagged images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,105 @@
 name: Docker Image CI
 
 on:
+  pull_request:
+    paths:
+      - 'docker/**'
   push:
     branches:
-      - master
+      - "master"
+      - "release/**"
+    paths:
+      - 'docker/**'
+    tags:
+      - "v*.*.*"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to registry'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: security-tools-alliance
+  PROJECT: rengine-ng
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [celery, web, postgres, redis, ollama, certs, proxy]
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
+      - name: Get version
+        id: get_version
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request' || github.event.inputs.push_image == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/${{ matrix.image }}
+          file: ./docker/${{ matrix.image }}/Dockerfile
+          push: ${{ github.event_name != 'pull_request' || github.event.inputs.push_image == 'true' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PROJECT }}:rengine-${{ matrix.image }}-${{ steps.get_version.outputs.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PROJECT }}:rengine-${{ matrix.image }}-latest
+          platforms: ${{ matrix.platform }}
+
+  update-release:
+    needs: build-and-push
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
 
-      - name: Log in to GitHub's Container Registry
-        run: echo "${{ secrets.CONTAINER_REGISTRY_SECRET }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Build the Docker image
-        run: docker build . -t ghcr.io/Security-Tools-Alliance/rengine-ng:latest
-
-      - name: Push the Docker image
-        run: docker push ghcr.io/Security-Tools-Alliance/rengine-ng:latest
+      - name: Update release description
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_id=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/latest" | \
+            jq -r .id)
+          
+          images="celery web postgres redis ollama certs proxy"
+          image_list=""
+          for image in $images; do
+            image_list="${image_list}- ghcr.io/${{ env.OWNER }}/${{ env.PROJECT }}:rengine-${image}-${{ github.ref_name }}\n"
+          done
+          
+          body="Docker images for this release:\n${image_list}"
+          
+          curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/${release_id}" \
+            -d "{\"body\": \"$body\"}"

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -1,0 +1,51 @@
+name: Delete Untagged GHCR Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (does not delete images)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: security-tools-alliance
+  PROJECT: rengine-ng
+
+jobs:
+  delete-untagged-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Delete untagged images
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v3
+        with:
+          token: ${{ secrets.GHCR_PAT }}
+          repository_owner: ${{ env.OWNER }}
+          repository: ${{ env.PROJECT }}
+          untagged_only: true
+          owner_type: org
+          except_untagged_multiplatform: true
+          dry_run: ${{ github.event.inputs.dry_run }}
+
+      - name: Summary
+        if: always()
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          echo "## Summary of untagged image deletion" >> $GITHUB_STEP_SUMMARY
+          echo "- Dry run: $DRY_RUN" >> $GITHUB_STEP_SUMMARY
+          echo "- Owner: $OWNER" >> $GITHUB_STEP_SUMMARY
+          echo "- Project: $PROJECT" >> $GITHUB_STEP_SUMMARY
+          echo "Check the logs above for more details on deleted images or images that would have been deleted in dry run mode." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Image creation has been restricted to the docker folder
Tags are now generated for the current services, and version (eg: rengine-celery-v2.1.0)
I've also added a manual workflow to remove untagged images