### PR TITLE
build(images): restrict image creation, add correct tags and clean non tagged images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,14 @@ name: Docker Image CI
 
 on:
   pull_request:
+    paths:
+      - 'docker/**'
   push:
     branches:
       - "master"
       - "release/**"
+    paths:
+      - 'docker/**'
     tags:
       - "v*.*.*"
   release:
@@ -37,19 +41,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PROJECT }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Get version
+        id: get_version
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=latest" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -71,20 +70,10 @@ jobs:
           context: ./docker/${{ matrix.image }}
           file: ./docker/${{ matrix.image }}/Dockerfile
           push: ${{ github.event_name != 'pull_request' || github.event.inputs.push_image == 'true' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PROJECT }}:rengine-${{ matrix.image }}-${{ steps.get_version.outputs.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PROJECT }}:rengine-${{ matrix.image }}-latest
           platforms: ${{ matrix.platform }}
-          outputs: type=docker,dest=/tmp/image.tar
-
-      - name: Push image if exists
-        if: github.event.inputs.push_image == 'true'
-        run: |
-          if [ -f /tmp/image.tar ]; then
-            docker load --input /tmp/image.tar
-            docker push ${{ steps.meta.outputs.tags }}
-          else
-            echo "No image found to push"
-          fi
 
   update-release:
     needs: build-and-push

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -11,6 +11,8 @@ on:
         options:
         - 'true'
         - 'false'
+  schedule:
+    - cron: '0 0 1,15 * *'  # Exécute à minuit le 1er et le 15 de chaque mois
 
 env:
   REGISTRY: ghcr.io
@@ -29,7 +31,7 @@ jobs:
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Delete untagged images
-        uses: Chizkiyahu/delete-untagged-ghcr-action@v3
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v4
         with:
           token: ${{ secrets.GHCR_PAT }}
           repository_owner: ${{ env.OWNER }}
@@ -37,12 +39,11 @@ jobs:
           untagged_only: true
           owner_type: org
           except_untagged_multiplatform: true
-          dry_run: ${{ github.event.inputs.dry_run }}
 
       - name: Summary
         if: always()
         env:
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           echo "## Summary of untagged image deletion" >> $GITHUB_STEP_SUMMARY
           echo "- Dry run: $DRY_RUN" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -12,7 +12,7 @@ on:
         - 'true'
         - 'false'
   schedule:
-    - cron: '0 0 1,15 * *'  # Exécute à minuit le 1er et le 15 de chaque mois
+    - cron: '0 0 1,15 * *'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -1,0 +1,51 @@
+name: Delete Untagged GHCR Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (does not delete images)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: security-tools-alliance
+  PROJECT: rengine-ng
+
+jobs:
+  delete-untagged-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Delete untagged images
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v3
+        with:
+          token: ${{ secrets.GHCR_PAT }}
+          repository_owner: ${{ env.OWNER }}
+          repository: ${{ env.PROJECT }}
+          untagged_only: true
+          owner_type: org
+          except_untagged_multiplatform: true
+          dry_run: ${{ github.event.inputs.dry_run }}
+
+      - name: Summary
+        if: always()
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          echo "## Summary of untagged image deletion" >> $GITHUB_STEP_SUMMARY
+          echo "- Dry run: $DRY_RUN" >> $GITHUB_STEP_SUMMARY
+          echo "- Owner: $OWNER" >> $GITHUB_STEP_SUMMARY
+          echo "- Project: $PROJECT" >> $GITHUB_STEP_SUMMARY
+          echo "Check the logs above for more details on deleted images or images that would have been deleted in dry run mode." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Image creation has been restricted to the docker folder
Tags are now generated for the current services, and version (eg: rengine-celery-v2.1.0)
I've also added a manual workflow to remove untagged images