### PR TITLE
build(ci): improve CodeQL configuration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,35 +1,46 @@
-name: "Code Quality"
+name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "**" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
   pull_request:
-    branches: [ master ]
-  schedule:
-    - cron: '0 18 * * 5'
+    branches: [ "**" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python' ]
+        include:
+        - language: javascript
+          build-mode: none
+        - language: python
+          build-mode: none
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+        build-mode: ${{ matrix.build-mode }}
+        queries: security-and-quality
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This PR gets rid of the cron-based scanning, and now always scans for code improvements upon every PR or push. It also uses [the extra suite](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-queries-in-ql-packs) `security-and-quality`. Finally, to prevent the workflow from running, text and Markdown files are ignored.