### PR TITLE
build(docker): replace staticfiles volume to prevent empty directory

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -147,7 +147,7 @@ services:
         target: /etc/nginx/certs/rengine_rsa.key
     volumes:
       - ./proxy/config/rengine.conf:/etc/nginx/conf.d/rengine.conf:ro
-      - ../web/staticfiles:/home/rengine/rengine/staticfiles/
+      - ../web:/home/rengine/rengine:rw,z
       - scan_results:/home/rengine/scan_results
     networks:
       - rengine_network


### PR DESCRIPTION
Fix staticfiles empty in proxy container
Staticfiles are the files for the UI (JS, CSS ...)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the staticfiles volume configuration in the Docker Compose file to prevent the directory from being empty in the proxy container.

Bug Fixes:
- Fix the issue of staticfiles being empty in the proxy container by adjusting the volume configuration in the Docker Compose file.

<!-- Generated by sourcery-ai[bot]: end summary -->