### PR TITLE
feat(ui): disable update button in tool arsenal

### DIFF
--- a/web/scanEngine/templates/scanEngine/settings/tool_arsenal.html
+++ b/web/scanEngine/templates/scanEngine/settings/tool_arsenal.html
@@ -92,7 +92,7 @@ Tool Arsenal
           {{tool.description}}
         </p>
         <div class="text-center mt-auto">
-          <button type="button" class="btn btn-primary waves-effect waves-light me-1" onclick="get_external_tool_latest_version('{{tool.id}}', '{{tool.name}}')"><i class="mdi mdi-download me-1"></i> Check Update</button>
+          <button type="button" class="btn btn-primary waves-effect waves-light me-1"><i class="mdi mdi-download me-1"></i>Update disabled<br/><small>&nbsp;&nbsp;(Coming soon)</small></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Disabled the "Check Update" button in the Tool Arsenal section and replaced it with a placeholder indicating that the update feature is coming soon.

As we have moved to a poetry management for the python libs, permit update could break things.
When issue #143 will be solved we could restablish the update system.
Anyway we will frequently push new images with latest tool