### PR TITLE
ci: add BUILDX_NO_DEFAULT_ATTESTATIONS environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ env:
   REGISTRY: ghcr.io
   OWNER: security-tools-alliance
   PROJECT: rengine-ng
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
 jobs:
   build-and-push:


### PR DESCRIPTION
- Added the BUILDX_NO_DEFAULT_ATTESTATIONS environment variable to the GitHub Actions build workflow configuration.