### PR TITLE
feat: add GPU support for NVIDIA & AMD GPUs in installation and Docker setup (ollama)

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -49,11 +49,7 @@ DJANGO_SUPERUSER_PASSWORD=Sm7IJG.IfHAFw9snSKv
 # Set GPU=1 to enable GPU support (default: 0 for CPU only)
 # GPU_TYPE will be automatically set during installation (nvidia or rocm)
 # DOCKER_RUNTIME will match GPU_TYPE when GPU support is enabled
-# GPU_CAPABILITIES depends on GPU_TYPE:
-#   - For NVIDIA: compute,utility
-#   - For AMD: gpu
 #
 GPU=0
 GPU_TYPE=none
 DOCKER_RUNTIME=none
-GPU_CAPABILITIES=none

--- a/.env-dist
+++ b/.env-dist
@@ -43,3 +43,17 @@ INSTALL_TYPE=prebuilt
 DJANGO_SUPERUSER_USERNAME=rengine
 DJANGO_SUPERUSER_EMAIL=rengine@example.com
 DJANGO_SUPERUSER_PASSWORD=Sm7IJG.IfHAFw9snSKv
+
+#
+# GPU Configuration for Ollama LLM
+# Set GPU=1 to enable GPU support (default: 0 for CPU only)
+# GPU_TYPE will be automatically set during installation (nvidia or rocm)
+# DOCKER_RUNTIME will match GPU_TYPE when GPU support is enabled
+# GPU_CAPABILITIES depends on GPU_TYPE:
+#   - For NVIDIA: compute,utility
+#   - For AMD: gpu
+#
+GPU=0
+GPU_TYPE=none
+DOCKER_RUNTIME=none
+GPU_CAPABILITIES=none

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ COMPOSE_FILE	      := docker/docker-compose.yml
 COMPOSE_FILE_BUILD	  := docker/docker-compose.build.yml
 COMPOSE_FILE_DEV      := docker/docker-compose.dev.yml
 COMPOSE_FILE_SETUP    := docker/docker-compose.setup.yml
+COMPOSE_FILE_GPU      := docker/docker-compose.gpu.yml
 SERVICES              := db web proxy redis celery celery-beat ollama
 
 # Check if 'docker compose' command is available, otherwise check for 'docker-compose'
@@ -36,7 +37,26 @@ $(info Using: $(DOCKER_COMPOSE))
 DOCKER_COMPOSE_CMD      := ${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE}
 DOCKER_COMPOSE_FILE_CMD := ${DOCKER_COMPOSE_CMD} -f ${COMPOSE_FILE}
 
-# --------------------------
+# Add GPU variable with default value
+GPU ?= 0
+
+# Function to handle GPU configuration
+define gpu_config
+	$(if $(filter 1,$(GPU)), \
+		$(eval GPU_TYPE := $(shell ./scripts/gpu_support.sh)) \
+		$(if $(filter nvidia,$(GPU_TYPE)), \
+			$(eval DOCKER_RUNTIME := nvidia) \
+			$(eval GPU_CAPABILITIES := compute,utility) \
+			$(eval COMPOSE_GPU_FILE := -f ${COMPOSE_FILE_GPU}), \
+			$(if $(filter rocm,$(GPU_TYPE)), \
+				$(eval DOCKER_RUNTIME := rocm) \
+				$(eval GPU_CAPABILITIES := gpu) \
+				$(eval COMPOSE_GPU_FILE := -f ${COMPOSE_FILE_GPU}), \
+				$(error No supported GPU detected) \
+			) \
+		), \
+	)
+endef
 
 .PHONY: certs up dev_up build_up build pull superuser_create superuser_delete superuser_changepassword migrate down stop restart remove_images test logs images prune help
 
@@ -46,9 +66,10 @@ pull:			## Pull pre-built Docker images from repository.
 images:			## Show all Docker images for reNgine services.
 	@docker images --filter=reference='ghcr.io/security-tools-alliance/rengine-ng:*' --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}"
 
-build:			## Build all Docker images locally.
+build:			## Build all Docker images locally. Use GPU=1 to enable GPU support.
 	@make remove_images
-	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_BUILD} build ${SERVICES}
+	$(call gpu_config)
+	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_BUILD} ${COMPOSE_GPU_FILE} build ${SERVICES}
 
 build_up:		## Build and start all services.
 	@make down
@@ -58,12 +79,14 @@ build_up:		## Build and start all services.
 certs:		    ## Generate certificates.
 	@${DOCKER_COMPOSE_CMD} -f ${COMPOSE_FILE_SETUP} run --rm certs
 
-up:				## Pull and start all services.
-	${DOCKER_COMPOSE_FILE_CMD} up -d ${SERVICES}
+up:				## Pull and start all services. Use GPU=1 to enable GPU support.
+	$(call gpu_config)
+	${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} up -d ${SERVICES}
 
-dev_up:			## Pull and start all services with development configuration (more debug logs and Django Toolbar in UI).
+dev_up:			## Pull and start all services with development configuration. Use GPU=1 to enable GPU support.
 	@make down
-	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} up -d ${SERVICES}
+	$(call gpu_config)
+	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} up -d ${SERVICES}
 
 superuser_create:		## Generate username (use only after `make up`).
 ifeq ($(isNonInteractive), true)
@@ -92,44 +115,45 @@ stop:			## Stop all services.
 	${DOCKER_COMPOSE_FILE_CMD} stop ${SERVICES}
 
 restart:		## Restart specified services or all if not specified. Use DEV=1 for development mode, COLD=1 for down and up instead of restart.
+	$(call gpu_config)
 	@if [ "$(COLD)" = "1" ]; then \
 		if [ "$(DEV)" = "1" ]; then \
 			if [ -n "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
 				echo "Cold restart $(filter-out $@,$(MAKECMDGOALS)) in dev mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} down $(filter-out $@,$(MAKECMDGOALS)); \
-				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} up -d $(filter-out $@,$(MAKECMDGOALS)); \
+				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} down $(filter-out $@,$(MAKECMDGOALS)); \
+				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} up -d $(filter-out $@,$(MAKECMDGOALS)); \
 			else \
 				echo "Cold restart ${SERVICES} in dev mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} down; \
-				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} up -d ${SERVICES}; \
+				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} down; \
+				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} up -d ${SERVICES}; \
 			fi \
 		else \
 			if [ -n "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
 				echo "Cold restart $(filter-out $@,$(MAKECMDGOALS)) in production mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} down $(filter-out $@,$(MAKECMDGOALS)); \
-				${DOCKER_COMPOSE_FILE_CMD} up -d $(filter-out $@,$(MAKECMDGOALS)); \
+				${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} down $(filter-out $@,$(MAKECMDGOALS)); \
+				${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} up -d $(filter-out $@,$(MAKECMDGOALS)); \
 			else \
 				echo "Cold restart ${SERVICES} in production mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} down; \
-				${DOCKER_COMPOSE_FILE_CMD} up -d ${SERVICES}; \
+				${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} down; \
+				${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} up -d ${SERVICES}; \
 			fi \
 		fi \
 	else \
 		if [ "$(DEV)" = "1" ]; then \
 			if [ -n "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
 				echo "Restart $(filter-out $@,$(MAKECMDGOALS)) in dev mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} restart $(filter-out $@,$(MAKECMDGOALS)); \
+				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} restart $(filter-out $@,$(MAKECMDGOALS)); \
 			else \
 				echo "Restart ${SERVICES} in dev mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} restart ${SERVICES}; \
+				${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_DEV} ${COMPOSE_GPU_FILE} restart ${SERVICES}; \
 			fi \
 		else \
 			if [ -n "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
 				echo "Restart $(filter-out $@,$(MAKECMDGOALS)) in production mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} restart $(filter-out $@,$(MAKECMDGOALS)); \
+				${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} restart $(filter-out $@,$(MAKECMDGOALS)); \
 			else \
 				echo "Restart ${SERVICES} in production mode"; \
-				${DOCKER_COMPOSE_FILE_CMD} restart ${SERVICES}; \
+				${DOCKER_COMPOSE_FILE_CMD} ${COMPOSE_GPU_FILE} restart ${SERVICES}; \
 			fi \
 		fi \
 	fi
@@ -159,7 +183,10 @@ help:			## Show this help.
 	@echo "Manage Docker images, containers and Django commands using Docker Compose files."
 	@echo ""
 	@echo "Usage:"
-	@echo "  make <target> (default: help)"
+	@echo "  make <target> [GPU=1] (default: help)"
+	@echo ""
+	@echo "Options:"
+	@echo "  GPU=1                                    Enable GPU support for Ollama LLM"
 	@echo ""
 	@echo "Targets:"
 	@echo "  make restart [service1] [service2] ...  				Restart specific services in production mode"
@@ -170,6 +197,12 @@ help:			## Show this help.
 	@echo "  make restart DEV=1 COLD=1 [service1] [service2] ...  	Cold restart (recreate containers) specific services in development mode"
 	@echo "  make restart COLD=1                     				Cold restart (recreate containers) all services in production mode"
 	@echo "  make restart DEV=1 COLD=1               				Cold restart (recreate containers) all services in development mode"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make up GPU=1                          				Start all services with GPU support"
+	@echo "  make dev_up GPU=1                      				Start development environment with GPU support"
+	@echo "  make build GPU=1                       				Build all images with GPU support"
+	@echo "  make build_up GPU=1                    				Build and start all services with GPU support"
 
 %:
 	@:

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -10,20 +10,12 @@ services:
       resources:
         reservations:
           devices:
-            - driver: ${DOCKER_RUNTIME}
+            - driver: nvidia
               count: all
               capabilities: [gpu]
     environment:
-      # GPU Settings
+      # NVIDIA Settings
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
-      - HSA_OVERRIDE_GFX_VERSION=10.3.0
-      - ROCR_VISIBLE_DEVICES=all
-    group_add:
-      - video
-      - render
-    devices:
-      - /dev/kfd:/dev/kfd  # AMD ROCm specific
-      - /dev/dri:/dev/dri  # AMD ROCm specific
     profiles:
       - gpu

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -5,19 +5,25 @@ services:
       service: ollama
     build:
       context: ./ollama
-      dockerfile: ${GPU_TYPE:-none}.Dockerfile
-    runtime: ${DOCKER_RUNTIME:-none}
-    when: ${GPU:-0} = 1
-    environment:
-      # NVIDIA Settings
-      - NVIDIA_VISIBLE_DEVICES=${GPU_DEVICES:-all}
-      - NVIDIA_DRIVER_CAPABILITIES=${GPU_CAPABILITIES:-compute,utility}
-      # ROCm Settings
-      - HSA_OVERRIDE_GFX_VERSION=${ROCM_VERSION:-9.0.0}
-      - ROCR_VISIBLE_DEVICES=${GPU_DEVICES:-all}
+      dockerfile: ${GPU_TYPE:+${GPU_TYPE}.Dockerfile}
     deploy:
       resources:
         reservations:
           devices:
-            - capabilities: [${GPU_CAPABILITIES:-none}]
+            - driver: ${DOCKER_RUNTIME}
               count: all
+              capabilities: [gpu]
+    environment:
+      # GPU Settings
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - HSA_OVERRIDE_GFX_VERSION=10.3.0
+      - ROCR_VISIBLE_DEVICES=all
+    group_add:
+      - video
+      - render
+    devices:
+      - /dev/kfd:/dev/kfd  # AMD ROCm specific
+      - /dev/dri:/dev/dri  # AMD ROCm specific
+    profiles:
+      - gpu

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -1,0 +1,23 @@
+services:
+  ollama:
+    extends:
+      file: docker-compose.yml
+      service: ollama
+    build:
+      context: ./ollama
+      dockerfile: ${GPU_TYPE:-none}.Dockerfile
+    runtime: ${DOCKER_RUNTIME:-none}
+    when: ${GPU:-0} = 1
+    environment:
+      # NVIDIA Settings
+      - NVIDIA_VISIBLE_DEVICES=${GPU_DEVICES:-all}
+      - NVIDIA_DRIVER_CAPABILITIES=${GPU_CAPABILITIES:-compute,utility}
+      # ROCm Settings
+      - HSA_OVERRIDE_GFX_VERSION=${ROCM_VERSION:-9.0.0}
+      - ROCR_VISIBLE_DEVICES=${GPU_DEVICES:-all}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [${GPU_CAPABILITIES:-none}]
+              count: all

--- a/docker/ollama/Dockerfile
+++ b/docker/ollama/Dockerfile
@@ -1,1 +1,5 @@
 FROM ollama/ollama:0.3.6
+
+# Add labels for GPU support information
+LABEL com.rengine.gpu-support="optional"
+LABEL com.rengine.gpu-description="GPU support can be enabled using docker-compose.gpu.yml"

--- a/docker/ollama/amd.Dockerfile
+++ b/docker/ollama/amd.Dockerfile
@@ -1,0 +1,9 @@
+FROM ollama/ollama:0.3.6
+
+# Enable ROCm support
+ENV HSA_OVERRIDE_GFX_VERSION=9.0.0
+ENV ROCR_VISIBLE_DEVICES=all
+
+# Add labels for GPU support information
+LABEL com.rengine.gpu-support="enabled-amd"
+LABEL com.rengine.gpu-description="AMD GPU support is enabled in this image"

--- a/docker/ollama/nvidia.Dockerfile
+++ b/docker/ollama/nvidia.Dockerfile
@@ -1,0 +1,9 @@
+FROM ollama/ollama:0.3.6
+
+# Enable NVIDIA GPU support
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Add labels for GPU support information
+LABEL com.rengine.gpu-support="enabled-nvidia"
+LABEL com.rengine.gpu-description="NVIDIA GPU support is enabled in this image"

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -4,6 +4,11 @@
 poetry run -C $HOME/ python3 manage.py collectstatic --noinput
 
 # Run production server
-poetry run -C $HOME/ gunicorn reNgine.wsgi:application -w 8 --bind 0.0.0.0:8000 --limit-request-line 0
+poetry run -C $HOME/ gunicorn reNgine.wsgi:application \
+    --workers 8 \
+    --bind 0.0.0.0:8000 \
+    --limit-request-line 0 \
+    --timeout 120 \
+    --keep-alive 120
 
 exec "$@"

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,9 @@
 # Import common functions
 source "$(pwd)/scripts/common_functions.sh" # Open the file if you want to know the meaning of each color
 
+# Import GPU support script
+source "$(pwd)/scripts/gpu_support.sh"
+
 # Fetch the internal and external IP address
 external_ip=$(curl -s https://ipecho.net/plain)
 internal_ips=$(ip -4 -br addr | awk '$2 == "UP" {print $3} /^lo/ {print $3}' | cut -d'/' -f1)
@@ -142,6 +145,142 @@ install_make() {
   install_package "make"
 }
 
+# Check GPU support and install required dependencies
+check_gpu_support() {
+    log "Checking for GPU support..." $COLOR_CYAN
+    
+    if grep -q "^GPU=" .env; then
+        GPU_ENABLED=$(grep "^GPU=" .env | cut -d '=' -f2)
+        if [ "$GPU_ENABLED" = "1" ]; then
+            log "GPU support is already enabled in .env" $COLOR_GREEN
+            return 0
+        else
+            log "GPU support is already disabled in .env" $COLOR_YELLOW
+            return 0
+        fi
+    fi
+    
+    # Execute GPU detection with error handling
+    if ! GPU_TYPE=$(./scripts/gpu_support.sh 2>/dev/null); then
+        log "GPU detection script failed, continuing with CPU-only setup" $COLOR_YELLOW
+        # Add default GPU configuration
+        {
+            echo "GPU=0"
+            echo "GPU_TYPE=none"
+            echo "DOCKER_RUNTIME=none"
+            echo "GPU_CAPABILITIES=none"
+        } >> .env
+        return 1
+    fi
+    
+    # Validate GPU_TYPE output
+    if [[ ! "$GPU_TYPE" =~ ^(nvidia|rocm|none)$ ]]; then
+        log "Invalid GPU type detected: $GPU_TYPE, continuing with CPU-only setup" $COLOR_YELLOW
+        # Add default GPU configuration
+        {
+            echo "GPU=0"
+            echo "GPU_TYPE=none"
+            echo "DOCKER_RUNTIME=none"
+            echo "GPU_CAPABILITIES=none"
+        } >> .env
+        return 1
+    fi
+    
+    case $GPU_TYPE in
+        "nvidia")
+            log "NVIDIA GPU detected" $COLOR_GREEN
+            if ! command -v nvidia-container-toolkit &> /dev/null; then
+                log "Installing NVIDIA Container Toolkit..." $COLOR_CYAN
+                
+                # Add NVIDIA repository key
+                if ! curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg; then
+                    log "Failed to add NVIDIA repository key" $COLOR_RED
+                    return 1
+                fi
+                
+                # Add NVIDIA repository
+                if ! curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+                    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+                    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null; then
+                    log "Failed to add NVIDIA repository" $COLOR_RED
+                    return 1
+                fi
+                
+                # Update package list
+                if ! sudo apt-get update; then
+                    log "Failed to update package list" $COLOR_RED
+                    return 1
+                fi
+                
+                # Install NVIDIA Container Toolkit
+                if ! sudo apt-get install -y nvidia-container-toolkit; then
+                    log "Failed to install NVIDIA Container Toolkit" $COLOR_RED
+                    return 1
+                fi
+                
+                # Configure Docker runtime
+                if ! sudo nvidia-ctk runtime configure --runtime=docker; then
+                    log "Failed to configure Docker runtime for NVIDIA" $COLOR_RED
+                    return 1
+                fi
+                
+                # Restart Docker service
+                if ! sudo systemctl restart docker; then
+                    log "Failed to restart Docker service" $COLOR_RED
+                    return 1
+                fi
+                
+                log "NVIDIA Container Toolkit installed successfully" $COLOR_GREEN
+            fi
+            return 0
+            ;;
+            
+        "rocm")
+            log "AMD GPU detected" $COLOR_GREEN
+            if ! command -v amdgpu-install &> /dev/null; then
+                log "Installing ROCm..." $COLOR_CYAN
+                
+                # Add ROCm repository key
+                if ! curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm.gpg; then
+                    log "Failed to add ROCm repository key" $COLOR_RED
+                    return 1
+                fi
+                
+                # Add ROCm repository
+                if ! echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian ubuntu main" | sudo tee /etc/apt/sources.list.d/rocm.list > /dev/null; then
+                    log "Failed to add ROCm repository" $COLOR_RED
+                    return 1
+                fi
+                
+                # Update package list
+                if ! sudo apt-get update; then
+                    log "Failed to update package list" $COLOR_RED
+                    return 1
+                fi
+                
+                # Install ROCm
+                if ! sudo apt-get install -y rocm-dev; then
+                    log "Failed to install ROCm" $COLOR_RED
+                    return 1
+                fi
+                
+                # Configure user groups
+                if ! sudo usermod -aG render $USER || ! sudo usermod -aG video $USER; then
+                    log "Failed to configure user groups" $COLOR_RED
+                    return 1
+                fi
+                
+                log "ROCm installed successfully" $COLOR_GREEN
+            fi
+            return 0
+            ;;
+            
+        *)
+            log "No supported GPU detected, continuing with CPU-only setup" $COLOR_YELLOW
+            return 1
+            ;;
+    esac
+}
 
 # Check for root privileges
 if [ $EUID -eq 0 ]; then
@@ -203,6 +342,91 @@ main() {
      esac
   done
 
+  log "Checking and installing reNgine-ng prerequisites..." $COLOR_CYAN
+
+  install_curl
+  install_make
+  check_docker
+  check_docker_compose
+
+  # Add GPU support check here
+  if check_gpu_support; then
+    # Check if GPU configuration already exists in .env
+    if grep -q "^GPU=1" .env; then
+        log "GPU support is already configured in .env" $COLOR_GREEN
+        return 0
+    fi
+
+    if [ $isNonInteractive = true ]; then
+        # Load existing GPU configuration from .env
+        if [ -f .env ]; then
+            GPU_ENABLED=$(grep "^GPU=" .env | cut -d '=' -f2)
+            if [ "$GPU_ENABLED" = "1" ]; then
+                # Remove existing GPU-related configurations
+                sed -i '/^GPU=/d' .env
+                sed -i '/^GPU_TYPE=/d' .env
+                sed -i '/^DOCKER_RUNTIME=/d' .env
+                sed -i '/^GPU_CAPABILITIES=/d' .env
+                
+                # Add GPU configuration to environment
+                {
+                    echo "GPU=1"
+                    echo "GPU_TYPE=$GPU_TYPE"
+                    echo "DOCKER_RUNTIME=$GPU_TYPE"
+                    if [ "$GPU_TYPE" = "nvidia" ]; then
+                        echo "GPU_CAPABILITIES=compute,utility"
+                    else
+                        echo "GPU_CAPABILITIES=gpu"
+                    fi
+                } >> .env
+                log "GPU support has been enabled from existing configuration" $COLOR_GREEN
+            else
+                log "GPU support is disabled in .env" $COLOR_YELLOW
+            fi
+        fi
+    else
+        log "Do you want to enable GPU support for Ollama? (recommended for better LLM performance) [y/n] " $COLOR_CYAN
+        read -p "" gpu_choice
+        case $gpu_choice in
+            [Yy]* )
+                # Remove existing GPU-related configurations
+                sed -i '/^GPU=/d' .env
+                sed -i '/^GPU_TYPE=/d' .env
+                sed -i '/^DOCKER_RUNTIME=/d' .env
+                sed -i '/^GPU_CAPABILITIES=/d' .env
+                
+                # Add GPU configuration to environment
+                {
+                    echo "GPU=1"
+                    echo "GPU_TYPE=$GPU_TYPE"
+                    echo "DOCKER_RUNTIME=$GPU_TYPE"
+                    if [ "$GPU_TYPE" = "nvidia" ]; then
+                        echo "GPU_CAPABILITIES=compute,utility"
+                    else
+                        echo "GPU_CAPABILITIES=gpu"
+                    fi
+                } >> .env
+                log "GPU support will be enabled" $COLOR_GREEN
+                ;;
+            * )
+                # Remove existing GPU-related configurations
+                sed -i '/^GPU=/d' .env
+                sed -i '/^GPU_TYPE=/d' .env
+                sed -i '/^DOCKER_RUNTIME=/d' .env
+                sed -i '/^GPU_CAPABILITIES=/d' .env
+                # Add default GPU configuration
+                {
+                    echo "GPU=0"
+                    echo "GPU_TYPE=none"
+                    echo "DOCKER_RUNTIME=none"
+                    echo "GPU_CAPABILITIES=none"
+                } >> .env
+                log "Continuing without GPU support" $COLOR_YELLOW
+                ;;
+        esac
+    fi
+  fi
+
   if [ $isNonInteractive = false ]; then
     read -p "Are you sure you made changes to the '.env' file (y/n)? " answer
     case ${answer:0:1} in
@@ -214,13 +438,6 @@ main() {
           nano .env
         ;;
     esac
-
-  log "Checking and installing reNgine-ng prerequisites..." $COLOR_CYAN
-
-  install_curl
-  install_make
-  check_docker
-  check_docker_compose
 
     log "Do you want to build Docker images from source or use pre-built images (recommended)? \nThis saves significant build time but requires good download speeds for it to complete fast." $COLOR_RED
     log "1) From source" $COLOR_YELLOW

--- a/scripts/gpu_support.sh
+++ b/scripts/gpu_support.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Check for GPU support and return the type
+detect_gpu_type() {
+    # Check for NVIDIA GPU using multiple methods
+    if command -v nvidia-smi &> /dev/null; then
+        # Check if nvidia-smi can actually communicate with a GPU
+        if nvidia-smi --query-gpu=gpu_name --format=csv,noheader &> /dev/null; then
+            echo "nvidia"
+            return 0
+        fi
+    fi
+
+    # Additional NVIDIA checks if nvidia-smi fails
+    if [ -d "/proc/driver/nvidia" ] || [ -d "/dev/nvidia0" ]; then
+        # Check for NVIDIA kernel module
+        if lsmod | grep -q "^nvidia "; then
+            echo "nvidia"
+            return 0
+        fi
+    fi
+
+    # Check for NVIDIA GPU in PCI devices
+    if lspci | grep -i "NVIDIA" | grep -i "VGA\|3D\|Display" &> /dev/null; then
+        # Check if the NVIDIA GPU is not disabled
+        if ! lspci -k | grep -A 2 -i "NVIDIA" | grep -i "Kernel driver in use: nouveau" &> /dev/null; then
+            echo "nvidia"
+            return 0
+        fi
+    fi
+
+    # Check for AMD GPU using multiple methods
+    if command -v rocminfo &> /dev/null; then
+        # Check if rocminfo can detect a GPU
+        if rocminfo 2>/dev/null | grep -q "GPU agent"; then
+            echo "rocm"
+            return 0
+        fi
+    fi
+
+    # Additional AMD checks
+    if lspci | grep -i "AMD" | grep -i "VGA\|3D\|Display" &> /dev/null; then
+        # Check for AMD GPU driver
+        if lsmod | grep -q "^amdgpu "; then
+            echo "rocm"
+            return 0
+        fi
+    fi
+
+    # No supported GPU found
+    echo "none"
+    return 1
+}
+
+# Log function for debugging
+debug_log() {
+    if [ "${DEBUG:-0}" = "1" ]; then
+        echo "[DEBUG] $1" >&2
+    fi
+}
+
+# If script is run directly, execute detection with optional debug info
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [ "${DEBUG:-0}" = "1" ]; then
+        debug_log "Checking PCI devices:"
+        lspci | grep -i "VGA\|3D\|Display" >&2
+        debug_log "Loaded kernel modules:"
+        lsmod | grep -E "nvidia|amdgpu" >&2
+    fi
+    detect_gpu_type
+fi

--- a/scripts/gpu_support.sh
+++ b/scripts/gpu_support.sh
@@ -33,7 +33,7 @@ detect_gpu_type() {
     if command -v rocminfo &> /dev/null; then
         # Check if rocminfo can detect a GPU
         if rocminfo 2>/dev/null | grep -q "GPU agent"; then
-            echo "rocm"
+            echo "amd"
             return 0
         fi
     fi
@@ -42,7 +42,7 @@ detect_gpu_type() {
     if lspci | grep -i "AMD" | grep -i "VGA\|3D\|Display" &> /dev/null; then
         # Check for AMD GPU driver
         if lsmod | grep -q "^amdgpu "; then
-            echo "rocm"
+            echo "amd"
             return 0
         fi
     fi

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -169,7 +169,6 @@ class OllamaManager(APIView):
                 defaults={
                     'selected_model': model_name,
                     'use_ollama': use_ollama,
-                    'selected': True
                 }
             )
             return Response({'status': True})

--- a/web/dashboard/admin.py
+++ b/web/dashboard/admin.py
@@ -3,5 +3,6 @@ from django.contrib import admin
 
 admin.site.register(SearchHistory)
 admin.site.register(Project)
+admin.site.register(OllamaSettings)
 admin.site.register(OpenAiAPIKey)
 admin.site.register(NetlasAPIKey)


### PR DESCRIPTION
Fixes #227 

Config for the 2 types of card has been added, but only NVIDIA GPU is effective and tested for the moment.
I don't have any AMD card to do testing.
Maybe later, but for now let's go with NVIDIA

## Summary by Sourcery

Add GPU support for NVIDIA and AMD GPUs in the installation and Docker setup, including scripts for GPU detection and configuration, and Dockerfiles for specific GPU types.

New Features:
- Introduce GPU support for NVIDIA and AMD GPUs in the installation script and Docker setup, allowing users to leverage GPU capabilities for enhanced performance.

Enhancements:
- Add a new script, gpu_support.sh, to detect GPU type and configure the environment accordingly.
- Update install.sh to check for GPU support and install necessary dependencies based on the detected GPU type.
- Modify the Makefile to include GPU configuration options, enabling users to activate GPU support during Docker operations.

Build:
- Create separate Dockerfiles for NVIDIA and AMD GPU support under the docker/ollama directory.
- Add a new Docker Compose file, docker-compose.gpu.yml, to handle GPU-specific configurations.

## Todo

- [x] NVIDIA test
- [ ] AMD test