### PR TITLE
fix(api): remove unused 'selected' field from OllamaManager defaults

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -169,7 +169,6 @@ class OllamaManager(APIView):
                 defaults={
                     'selected_model': model_name,
                     'use_ollama': use_ollama,
-                    'selected': True
                 }
             )
             return Response({'status': True})


### PR DESCRIPTION
Fixes #231 

## Summary by Sourcery

Bug Fixes:
- Remove the 'selected' field from the defaults dictionary in the OllamaManager class to prevent a 500 error during LLM selection.