### PR TITLE
fix(scan): resolve detection of the first endpoint in the initiate scan task

### DIFF
--- a/web/reNgine/celery_custom_task.py
+++ b/web/reNgine/celery_custom_task.py
@@ -109,7 +109,10 @@ class RengineTask(Task):
 
 			# Create ScanActivity for this task and send start scan notifs
 			if self.track:
-				logger.warning(f'Task {self.task_name} is RUNNING')
+				if self.domain:
+					logger.warning(f'Task {self.task_name} for {self.subdomain.name if self.subdomain else self.domain.name} is RUNNING')
+				else:
+					logger.warning(f'Task {self.task_name} is RUNNING')
 				self.create_scan_activity()
 
 		if RENGINE_CACHE_ENABLED:
@@ -119,7 +122,10 @@ class RengineTask(Task):
 			if result and result != b'null':
 				self.status = SUCCESS_TASK
 				if RENGINE_RECORD_ENABLED and self.track:
-					logger.warning(f'Task {self.task_name} status is SUCCESS (CACHED)')
+					if self.domain:
+						logger.warning(f'Task {self.task_name} for {self.subdomain.name if self.subdomain else self.domain.name} status is SUCCESS (CACHED)')
+					else:
+						logger.warning(f'Task {self.task_name} status is SUCCESS (CACHED)')
 					self.update_scan_activity()
 				return json.loads(result)
 
@@ -150,7 +156,10 @@ class RengineTask(Task):
 			self.write_results()
 
 			if RENGINE_RECORD_ENABLED and self.track:
-				msg = f'Task {self.task_name} status is {self.status_str}'
+				if self.domain:
+					msg = f'Task {self.task_name} for {self.subdomain.name if self.subdomain else self.domain.name} status is {self.status_str}'
+				else:
+					msg = f'Task {self.task_name} status is {self.status_str}'
 				msg += f' | Error: {self.error}' if self.error else ''
 				logger.warning(msg)
 				self.update_scan_activity()

--- a/web/reNgine/exceptions.py
+++ b/web/reNgine/exceptions.py
@@ -1,0 +1,3 @@
+class NmapScanError(Exception):
+    """Exception raised when Nmap scan fails."""
+    pass

--- a/web/reNgine/exceptions.py
+++ b/web/reNgine/exceptions.py
@@ -1,3 +1,0 @@
-class NmapScanError(Exception):
-    """Exception raised when Nmap scan fails."""
-    pass

--- a/web/reNgine/settings.py
+++ b/web/reNgine/settings.py
@@ -45,7 +45,7 @@ DEBUG = env.bool('UI_DEBUG', default=False)
 DOMAIN_NAME = env('DOMAIN_NAME', default='localhost:8000')
 TEMPLATE_DEBUG = env.bool('TEMPLATE_DEBUG', default=False)
 SECRET_FILE = os.path.join(RENGINE_HOME, 'secret')
-DEFAULT_ENABLE_HTTP_CRAWL = env.bool('DEFAULT_ENABLE_HTTP_CRAWL', default=True)
+DEFAULT_ENABLE_HTTP_CRAWL = env.bool('DEFAULT_ENABLE_HTTP_CRAWL', default=False)
 DEFAULT_RATE_LIMIT = env.int('DEFAULT_RATE_LIMIT', default=150) # requests / second
 DEFAULT_HTTP_TIMEOUT = env.int('DEFAULT_HTTP_TIMEOUT', default=5) # seconds
 DEFAULT_RETRIES = env.int('DEFAULT_RETRIES', default=1)

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1508,7 +1508,6 @@ def run_nmap(self, ctx, **nmap_args):
     """
     sigs = []
     for host, port_list in nmap_args.get('ports_data', {}).items():
-        ports_str = '_'.join([str(p) for p in port_list])
         ctx_nmap = ctx.copy()
         ctx_nmap['description'] = get_task_title(f'nmap_{host}', self.scan_id, self.subscan_id)
         ctx_nmap['track'] = False
@@ -1523,7 +1522,7 @@ def run_nmap(self, ctx, **nmap_args):
         sigs.append(sig)
     task = group(sigs).apply_async()
     with allow_join_result():
-        results = task.get()
+        task.get()
 
 
 @app.task(name='nmap', queue='main_scan_queue', base=RengineTask, bind=True)
@@ -1627,7 +1626,6 @@ def waf_detection(self, ctx={}, description=None):
     """
     input_path = str(Path(self.results_dir) / 'input_endpoints_waf_detection.txt')
     config = self.yaml_configuration.get(WAF_DETECTION) or {}
-    enable_http_crawl = get_http_crawl_value(self, config)
 
     # Get alive endpoints from DB
     urls = get_http_urls(

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -30,7 +30,6 @@ from metafinder.extractor import extract_metadata_from_google_search
 from reNgine.celery import app
 from reNgine.gpt import GPTVulnerabilityReportGenerator
 from reNgine.celery_custom_task import RengineTask
-from reNgine.exceptions import NmapScanError
 from reNgine.common_func import *
 from reNgine.definitions import *
 from reNgine.settings import *

--- a/web/reNgine/utilities.py
+++ b/web/reNgine/utilities.py
@@ -1,8 +1,11 @@
 import os
-
+import re
+from pathlib import Path
+from typing import List, Union
+from celery.utils.log import get_task_logger, ColorFormatter
 from celery._state import get_current_task
-from celery.utils.log import ColorFormatter
 
+logger = get_task_logger(__name__)
 
 def is_safe_path(basedir, path, follow_symlinks=True):
 	# Source: https://security.openstack.org/guidelines/dg_using-file-paths.html
@@ -86,3 +89,90 @@ def replace_nulls(obj):
 		return {key: replace_nulls(value) for key, value in obj.items()}
 	else:
 		return obj
+
+
+class SafePath:
+	"""Utility class for safe path handling and directory creation."""
+	
+	@staticmethod
+	def sanitize_component(component: str) -> str:
+		"""Sanitize a path component to prevent directory traversal.
+		
+		Args:
+			component (str): Path component to sanitize
+			
+		Returns:
+			str: Sanitized path component
+		"""
+		# Remove any non-alphanumeric chars except safe ones
+		return re.sub(r'[^a-zA-Z0-9\-\_\.]', '_', str(component))
+
+	@classmethod
+	def create_safe_path(
+		cls,
+		base_dir: Union[str, Path],
+		components: List[str],
+		create_dir: bool = True,
+		mode: int = 0o755
+	) -> str:
+		"""Create a safe path within the base directory.
+		
+		Args:
+			base_dir (str|Path): Base directory
+			components (list): List of path components
+			create_dir (bool): Whether to create the directory
+			mode (int): Directory permissions if created
+			
+		Returns:
+			str: Safe path object
+			
+		Raises:
+			ValueError: If path would be outside base directory
+			OSError: If directory creation fails
+		"""
+		try:
+			# Convert to Path objects
+			base_path = Path(base_dir).resolve()
+			
+			# Sanitize all components
+			safe_components = [cls.sanitize_component(c) for c in components]
+			
+			# Build full path
+			full_path = base_path.joinpath(*safe_components)
+			
+			# Resolve to absolute path
+			abs_path = full_path.resolve()
+			
+			# Check if path is within base directory
+			if not str(abs_path).startswith(str(base_path)):
+				raise ValueError(
+					f"Invalid path: {abs_path} is outside base directory {base_path}"
+				)
+			
+			# Create directory if requested
+			if create_dir:
+				abs_path.mkdir(parents=True, mode=mode, exist_ok=True)
+				logger.debug(f"Created directory: {abs_path}")
+				
+			return str(abs_path)
+			
+		except Exception as e:
+			logger.error(f"Error creating safe path: {str(e)}")
+			raise
+
+	@classmethod
+	def is_safe_path(cls, base_dir: Union[str, Path], path: Union[str, Path], follow_symlinks: bool = True) -> bool:
+		"""Enhanced version of is_safe_path that uses pathlib.
+		Maintains compatibility with existing code while adding more security."""
+		try:
+			base_path = Path(base_dir).resolve()
+			check_path = Path(path)
+			
+			if follow_symlinks:
+				check_path = check_path.resolve()
+			else:
+				check_path = check_path.absolute()
+				
+			return str(check_path).startswith(str(base_path))
+		except Exception:
+			return False

--- a/web/startScan/models.py
+++ b/web/startScan/models.py
@@ -575,7 +575,7 @@ class Port(models.Model):
 	is_uncommon = models.BooleanField(default=False)
 
 	def __str__(self):
-		return str(self.service_name)
+		return str(self.number)
 
 
 class DirectoryFile(models.Model):

--- a/web/tests/test_data/nmap/basic_scan.xml
+++ b/web/tests/test_data/nmap/basic_scan.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<nmaprun scanner="nmap" args="nmap -Pn -p 80,443 example.com" start="1234567890" startstr="2024-01-01 12:00:00" version="7.80" xmloutputversion="1.04">
+  <scaninfo type="syn" protocol="tcp" numservices="2" services="80,443"/>
+  <verbose level="0"/>
+  <debugging level="0"/>
+  <host starttime="1234567890" endtime="1234567899">
+    <status state="up" reason="user-set" reason_ttl="0"/>
+    <address addr="93.184.216.34" addrtype="ipv4"/>
+    <hostnames>
+      <hostname name="example.com" type="user"/>
+    </hostnames>
+    <ports>
+      <port protocol="tcp" portid="80">
+        <state state="open" reason="syn-ack" reason_ttl="0"/>
+        <service name="http" method="table" conf="3"/>
+      </port>
+      <port protocol="tcp" portid="443">
+        <state state="open" reason="syn-ack" reason_ttl="0"/>
+        <service name="https" method="table" conf="3"/>
+      </port>
+    </ports>
+  </host>
+  <runstats>
+    <finished time="1234567899" timestr="2024-01-01 12:00:09"/>
+    <hosts up="1" down="0" total="1"/>
+  </runstats>
+</nmaprun>

--- a/web/tests/test_data/nmap/service_scan.xml
+++ b/web/tests/test_data/nmap/service_scan.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<nmaprun scanner="nmap" args="nmap -sV -Pn -p 80,443,8080 example.com" start="1234567890" startstr="2024-01-01 12:00:00" version="7.80" xmloutputversion="1.04">
+  <scaninfo type="syn" protocol="tcp" numservices="3" services="80,443,8080"/>
+  <verbose level="0"/>
+  <debugging level="0"/>
+  <host starttime="1234567890" endtime="1234567899">
+    <status state="up" reason="user-set" reason_ttl="0"/>
+    <address addr="93.184.216.34" addrtype="ipv4"/>
+    <hostnames>
+      <hostname name="example.com" type="user"/>
+      <hostname name="www.example.com" type="PTR"/>
+    </hostnames>
+    <ports>
+      <port protocol="tcp" portid="80">
+        <state state="open" reason="syn-ack" reason_ttl="0"/>
+        <service name="http" product="nginx" version="1.18.0" method="probed" conf="10"/>
+      </port>
+      <port protocol="tcp" portid="443">
+        <state state="open" reason="syn-ack" reason_ttl="0"/>
+        <service name="https" product="nginx" version="1.18.0" tunnel="ssl" method="probed" conf="10"/>
+      </port>
+      <port protocol="tcp" portid="8080">
+        <state state="closed" reason="conn-refused" reason_ttl="0"/>
+        <service name="http-proxy" method="table" conf="3"/>
+      </port>
+    </ports>
+  </host>
+  <runstats>
+    <finished time="1234567899" timestr="2024-01-01 12:00:09"/>
+    <hosts up="1" down="0" total="1"/>
+  </runstats>
+</nmaprun>

--- a/web/tests/test_data/nmap/vuln_scan.xml
+++ b/web/tests/test_data/nmap/vuln_scan.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<nmaprun scanner="nmap" args="nmap -sV --script vuln -Pn -p 80,443 example.com" start="1234567890" startstr="2024-01-01 12:00:00" version="7.80" xmloutputversion="1.04">
+  <scaninfo type="syn" protocol="tcp" numservices="2" services="80,443"/>
+  <verbose level="0"/>
+  <debugging level="0"/>
+  <host starttime="1234567890" endtime="1234567899">
+    <status state="up" reason="user-set" reason_ttl="0"/>
+    <address addr="93.184.216.34" addrtype="ipv4"/>
+    <hostnames>
+      <hostname name="example.com" type="user"/>
+    </hostnames>
+    <ports>
+      <port protocol="tcp" portid="80">
+        <state state="open" reason="syn-ack" reason_ttl="0"/>
+        <service name="http" product="nginx" version="1.18.0" method="probed" conf="10"/>
+        <script id="http-csrf" output="Couldn't find any CSRF vulnerabilities."/>
+        <script id="http-dombased-xss" output="Couldn't find any DOM based XSS."/>
+        <script id="http-stored-xss" output="Couldn't find any stored XSS vulnerabilities."/>
+      </port>
+      <port protocol="tcp" portid="443">
+        <state state="open" reason="syn-ack" reason_ttl="0"/>
+        <service name="https" product="nginx" version="1.18.0" tunnel="ssl" method="probed" conf="10"/>
+        <script id="ssl-ccs-injection" output="No reply from server (TIMEOUT)"/>
+        <script id="ssl-heartbleed" output="VULNERABLE:&#xa;  The Heartbleed Bug is a serious vulnerability in the popular OpenSSL cryptographic software library"/>
+        <script id="ssl-poodle" output="VULNERABLE:&#xa;  SSL POODLE information leak, CVE-2014-3566"/>
+        <script id="sslv2-drown" output="VULNERABLE:&#xa;  SSLv2 DROWN attack, CVE-2016-0800"/>
+      </port>
+    </ports>
+    <hostscript>
+      <script id="vulners" output="&#xa;  cpe:/a:nginx:nginx:1.18.0: &#xa;    &#x9;CVE-2021-23017&#x9;7.5&#x9;https://vulners.com/cve/CVE-2021-23017"/>
+    </hostscript>
+  </host>
+  <runstats>
+    <finished time="1234567899" timestr="2024-01-01 12:00:09"/>
+    <hosts up="1" down="0" total="1"/>
+  </runstats>
+</nmaprun>

--- a/web/tests/test_nmap.py
+++ b/web/tests/test_nmap.py
@@ -33,7 +33,7 @@ class TestNmapParsing(unittest.TestCase):
 
     def test_nmap_parse(self):
         for xml_file in self.all_xml:
-            vulns = parse_nmap_results(self.nmap_vuln_single_xml)
+            vulns = parse_nmap_results(xml_file, parse_type='vulnerabilities')
             self.assertGreater(len(vulns), 0)  # Fixed to use len(vulns)
 
     def test_nmap_vuln_single(self):

--- a/web/tests/test_nmap.py
+++ b/web/tests/test_nmap.py
@@ -2,6 +2,8 @@ import logging
 import os
 import unittest
 import pathlib
+import pytest
+from pathlib import Path
 
 os.environ['RENGINE_SECRET_KEY'] = 'secret'
 os.environ['CELERY_ALWAYS_EAGER'] = 'True'
@@ -31,10 +33,39 @@ class TestNmapParsing(unittest.TestCase):
             self.nmap_vulscan_multiple_xml
         ]
 
-    def test_nmap_parse(self):
-        for xml_file in self.all_xml:
-            vulns = parse_nmap_results(xml_file, parse_type='vulnerabilities')
-            self.assertGreater(len(vulns), 0)  # Fixed to use len(vulns)
+    @pytest.mark.parametrize("xml_file", [
+        "web/tests/test_data/nmap/basic_scan.xml",
+        "web/tests/test_data/nmap/service_scan.xml",
+        "web/tests/test_data/nmap/vuln_scan.xml"
+    ])
+    def test_nmap_parse_vulnerabilities(self, xml_file):
+        """Test parsing vulnerabilities from Nmap XML output files."""
+        # Arrange
+        xml_path = Path(xml_file)
+        assert xml_path.exists(), f"Test file {xml_file} not found"
+        
+        # Act
+        vulns = parse_nmap_results(xml_path, parse_type='vulnerabilities')
+        
+        # Assert
+        assert len(vulns) > 0, f"No vulnerabilities found in {xml_file}"
+
+    @pytest.mark.parametrize("xml_file", [
+        "web/tests/test_data/nmap/basic_scan.xml",
+        "web/tests/test_data/nmap/service_scan.xml",
+        "web/tests/test_data/nmap/vuln_scan.xml"
+    ])
+    def test_nmap_parse_ports(self, xml_file):
+        """Test parsing ports from Nmap XML output files."""
+        # Arrange
+        xml_path = Path(xml_file)
+        assert xml_path.exists(), f"Test file {xml_file} not found"
+        
+        # Act
+        ports = parse_nmap_results(xml_path, parse_type='ports')
+        
+        # Assert
+        assert len(ports) > 0, f"No ports found in {xml_file}"
 
     def test_nmap_vuln_single(self):
         pass


### PR DESCRIPTION
Fixes #237 

- Replace HTTPx first scan by nmap, then launch HTTPx with discovered port
- Create a reusable function to launch nmap on the fly
- Add parsing to get ports and services from Nmap output
- Add more logs to debug scans while running
- Remove the HTTP CRAWL global var, Nmap is the default to retrieve the first endpoint (the starting point for all the others tasks)
- Adjust the is_alive parameter for tasks that need alive endpoints
- Fix S3 scanner source file not found
- Add more checks to prevent errors and scan crash
- Refactor Endpoint saving for a better logic and less errors
- Improve URLs validation

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the S3 scanner source file was not found, ensuring the correct file path is used.

Enhancements:
- Refactor the endpoint saving logic to improve clarity and reduce errors.
- Improve URL validation by adding a new function to check the validity of URLs, including domain:port formats.
- Add more logging to provide better insights during scan execution and debugging.

This PR prepared the ground to effectively resolve #208 & #8 

## Todo

- [x] Test initiate scan with Full scan
- [x] Test initiation subscan with all the scan type