### PR TITLE
fix(install): set rengine folder correctly & fix non interactive argument check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ include .env
 RENGINE_VERSION := $(shell cat web/reNgine/version.txt)
 export RENGINE_VERSION
 
+# Define RENGINE_FOLDER
+RENGINE_FOLDER := /home/$USERNAME/rengine
+export RENGINE_FOLDER
+
 # Credits: https://github.com/sherifabdlnaby/elastdocker/
 
 # This for future release of Compose that will use Docker Buildkit, which is much efficient.
@@ -67,23 +71,23 @@ dev_up:			## Pull and start all services with development configuration (more de
 
 superuser_create:		## Generate username (use only after `make up`).
 ifeq ($(isNonInteractive), true)
-	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C /home/rengine run python3 manage.py createsuperuser --username ${DJANGO_SUPERUSER_USERNAME} --email ${DJANGO_SUPERUSER_EMAIL} --noinput
+	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C ${RENGINE_FOLDER} run python3 manage.py createsuperuser --username ${DJANGO_SUPERUSER_USERNAME} --email ${DJANGO_SUPERUSER_EMAIL} --noinput
 else
-	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C /home/rengine run python3 manage.py createsuperuser
+	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C ${RENGINE_FOLDER} run python3 manage.py createsuperuser
 endif
 
 superuser_delete:		## Delete username (use only after `make up`).
-	${DOCKER_COMPOSE_FILE_CMD} exec -T web poetry -C /home/rengine run python3 manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.filter(username='${DJANGO_SUPERUSER_USERNAME}').delete()"
+	${DOCKER_COMPOSE_FILE_CMD} exec -T web poetry -C ${RENGINE_FOLDER} run python3 manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.filter(username='${DJANGO_SUPERUSER_USERNAME}').delete()"
 
 superuser_changepassword:	## Change password for user (use only after `make up` & `make username`).
 ifeq ($(isNonInteractive), true)
-	${DOCKER_COMPOSE_FILE_CMD} exec -T web poetry -C /home/rengine run python3 manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); u = User.objects.get(username='${DJANGO_SUPERUSER_USERNAME}'); u.set_password('${DJANGO_SUPERUSER_PASSWORD}'); u.save()"
+	${DOCKER_COMPOSE_FILE_CMD} exec -T web poetry -C ${RENGINE_FOLDER} run python3 manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); u = User.objects.get(username='${DJANGO_SUPERUSER_USERNAME}'); u.set_password('${DJANGO_SUPERUSER_PASSWORD}'); u.save()"
 else
-	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C /home/rengine run python3 manage.py changepassword
+	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C ${RENGINE_FOLDER} run python3 manage.py changepassword
 endif
 
 migrate:		## Apply Django migrations
-	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C /home/rengine run python3 manage.py migrate
+	${DOCKER_COMPOSE_FILE_CMD} exec web poetry -C ${RENGINE_FOLDER} run python3 manage.py migrate
 
 down:			## Down all services and remove containers.
 	${DOCKER_COMPOSE_FILE_CMD} down
@@ -144,7 +148,7 @@ remove_images:	## Remove all Docker images for reNgine-ng services.
 	fi
 
 test:
-	${DOCKER_COMPOSE_FILE_CMD} exec celery poetry -C /home/rengine run python3 -m unittest tests/test_scan.py
+	${DOCKER_COMPOSE_FILE_CMD} exec celery poetry -C ${RENGINE_FOLDER} run python3 -m unittest tests/test_scan.py
 
 logs:			## Tail all containers logs with -n 1000 (useful for debug).
 	${DOCKER_COMPOSE_FILE_CMD} logs --follow --tail=1000 ${SERVICES}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RENGINE_VERSION := $(shell cat web/reNgine/version.txt)
 export RENGINE_VERSION
 
 # Define RENGINE_FOLDER
-RENGINE_FOLDER := /home/$USERNAME/rengine
+RENGINE_FOLDER := /home/rengine/rengine
 export RENGINE_FOLDER
 
 # Credits: https://github.com/sherifabdlnaby/elastdocker/

--- a/install.sh
+++ b/install.sh
@@ -195,12 +195,25 @@ main() {
   tput setaf 1;
 
   isNonInteractive=false
-  while getopts nh opt; do
-     case $opt in
-        n) isNonInteractive=true ;;
-        h) usageFunction ;;
-        ?) usageFunction ;;
-     esac
+  # Get args from sudo or directly
+  args="${@:-${SUDO_COMMAND#*/install.sh }}"
+  for arg in $args
+  do
+    case $arg in
+      -n|--non-interactive)
+        isNonInteractive=true
+        ;;
+      -h|--help)
+        usageFunction
+        ;;
+      ./install.sh)
+        # Skip the script name
+        ;;
+      *)
+        log "Unknown argument: $arg" $COLOR_RED
+        usageFunction
+        ;;
+    esac
   done
 
   if [ $isNonInteractive = false ]; then
@@ -214,6 +227,7 @@ main() {
           nano .env
         ;;
     esac
+  fi
 
   log "Checking and installing reNgine-ng prerequisites..." $COLOR_CYAN
 
@@ -222,6 +236,7 @@ main() {
   check_docker
   check_docker_compose
 
+  if [ $isNonInteractive = false ]; then
     log "Do you want to build Docker images from source or use pre-built images (recommended)? \nThis saves significant build time but requires good download speeds for it to complete fast." $COLOR_RED
     log "1) From source" $COLOR_YELLOW
     log "2) Use pre-built images (default)" $COLOR_YELLOW


### PR DESCRIPTION
Fix #247

- Define and uses a new environment variable, RENGINE_FOLDER, to specify the reNgine installation directory. 
- Fix non interactive argument check not working while using sudo command

  - [x] Test install
  - [x] Test non interactive install