### PR TITLE
fix: rework sys_admin authorizations

### DIFF
--- a/web/commonFilters/templatetags/custom_filters.py
+++ b/web/commonFilters/templatetags/custom_filters.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
 from django import template
-
+from dashboard.utils import get_user_groups
 register = template.Library()
 
 
@@ -57,11 +57,4 @@ def previous(some_list, current_index):
 
 @register.filter(name='get_user_role')
 def get_user_role(user):
-    if user.groups.filter(name='sys_admin').exists():
-        return 'sys_admin'
-    elif user.groups.filter(name='auditor').exists():
-        return 'auditor'
-    elif user.groups.filter(name='penetration_tester').exists():
-        return 'penetration_tester'
-    else:
-        return 'unknown'
+    return get_user_groups(user)

--- a/web/dashboard/templates/dashboard/admin.html
+++ b/web/dashboard/templates/dashboard/admin.html
@@ -58,7 +58,9 @@ Admin Settings
               {% for muser in users %}
               <tr>
                 <th>
-                  {% if muser|has_role:'admin' %}
+                  {% if muser.is_superuser %}
+                    <span class="badge bg-soft-danger text-danger p-1">{{muser.username}}</span>
+                  {% elif muser|has_role:'sys_admin' %}
                     <span class="badge bg-soft-success text-success p-1">{{muser.username}}</span>
                   {% elif muser|has_role:'auditor' %}
                     <span class="badge bg-soft-pink text-pink p-1">{{muser.username}}</span>
@@ -74,12 +76,14 @@ Admin Settings
                   {% endif %}
                 </th>
                 <th>
-                  {% if muser|has_role:'sys_admin' %}
+                  {% if muser.is_superuser %}
+                    <span class="badge bg-soft-danger text-danger p-1">Super Admin</span>
+                  {% elif muser|has_role:'sys_admin' %}
                     <span class="badge bg-soft-success text-success p-1">Sys Admin</span>
                   {% elif muser|has_role:'auditor' %}
                     <span class="badge bg-soft-pink text-pink p-1">Auditor</span>
                   {% else %}
-                  <span class="badge bg-soft-primary text-primary p-1">Penetration Tester</span>
+                    <span class="badge bg-soft-primary text-primary p-1">Penetration Tester</span>
                   {% endif %}
                 </th>
                 <td>{{muser.date_joined|naturaltime}}</td>
@@ -99,34 +103,37 @@ Admin Settings
                 </td>
                 <td>
                   {% if user != muser %}
-                    {% if muser.is_active %}
-                    <a href="./update?mode=change_status&user={{ muser.id }}" class="action-icon" 
-                       data-bs-toggle="tooltip" data-bs-placement="bottom" title="Disable Account"> 
-                       <i class="mdi mdi-account-cancel"></i>
-                    </a>
+                    {% if user.is_superuser and muser.is_superuser or user|has_role:'sys_admin' and not muser.is_superuser %}
+                      {# Show action buttons for: superuser->superuser or sys_admin->non-superuser #}
+                      {% if muser.is_active %}
+                        <a href="./update?mode=change_status&user={{ muser.id }}" class="action-icon" 
+                           data-bs-toggle="tooltip" data-bs-placement="bottom" title="Disable Account"> 
+                           <i class="mdi mdi-account-cancel"></i>
+                        </a>
+                      {% else %}
+                        <a href="./update?mode=change_status&user={{ muser.id }}" class="action-icon" 
+                           data-bs-toggle="tooltip" data-bs-placement="bottom" title="Enable Account"> 
+                           <i class="mdi mdi-account-check"></i>
+                        </a>
+                      {% endif %}
+                      {% with user_role=muser|get_user_role %}
+                      {% with user_projects=muser.projects.all|map:'id'|join:',' %}
+                        <a href="#" onclick="update_user_modal({{ muser.id }}, '{{ user_role }}', [{{ user_projects }}])" 
+                          class="action-icon" id="change_user_details_btn" title="Update User Detail" 
+                          data-bs-toggle="tooltip" data-bs-placement="bottom"> 
+                          <i class="mdi mdi-account-edit"></i>
+                        </a>
+                      {% endwith %}
+                      {% endwith %}
+                      <a href="#" onclick="delete_user({{ muser.id }}, '{{ muser.username }}')" class="action-icon" 
+                        data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete Account"> 
+                        <i class="mdi mdi-trash-can"></i>
+                      </a>
                     {% else %}
-                    <a href="./update?mode=change_status&user={{ muser.id }}" class="action-icon" 
-                       data-bs-toggle="tooltip" data-bs-placement="bottom" title="Enable Account"> 
-                       <i class="mdi mdi-account-check"></i>
-                    </a>
+                      &nbsp;
                     {% endif %}
                   {% else %}
-                  &nbsp;
-                  {% endif %}
-                  {% with user_role=muser|get_user_role %}
-                  {% with user_projects=muser.projects.all|map:'id'|join:',' %}
-                  <a href="#" onclick="update_user_modal({{ muser.id }}, '{{ user_role }}', [{{ user_projects }}])" 
-                     class="action-icon" id="change_user_details_btn" title="Update User Detail" 
-                     data-bs-toggle="tooltip" data-bs-placement="bottom"> 
-                     <i class="mdi mdi-account-edit"></i>
-                  </a>
-                  {% endwith %}
-                  {% endwith %}
-                  {% if user != muser %}
-                  <a href="#" onclick="delete_user({{ muser.id }}, '{{ muser.username }}')" class="action-icon" 
-                     data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete Account"> 
-                     <i class="mdi mdi-trash-can"></i>
-                  </a>
+                    &nbsp;
                   {% endif %}
                 </td>
               </tr>

--- a/web/dashboard/tests/test_dashboard.py
+++ b/web/dashboard/tests/test_dashboard.py
@@ -6,9 +6,9 @@ from unittest.mock import patch, MagicMock
 from django.urls import reverse
 from utils.test_base import BaseTestCase
 from django.contrib.auth.models import User
-from rolepermissions.checkers import has_role
-from reNgine.roles import SysAdmin, PenetrationTester
 from django.utils import timezone
+from rolepermissions.roles import assign_role
+import uuid
 
 __all__ = [
     'TestDashboardViews'
@@ -100,62 +100,110 @@ class AdminInterfaceUpdateTests(BaseTestCase):
     def setUp(self):
         super().setUp()
         self.data_generator.create_project_full()
-        self.user_to_test = User.objects.create_user(username='testuser', password='12345')
+        
+        # Create users with different roles
+        self.superuser = User.objects.create_superuser(username='superadmin', password='password123')
+        self.sys_admin = User.objects.create_user(username='sysadmin', password='password123')
+        assign_role(self.sys_admin, 'sys_admin')
+        self.normal_user = User.objects.create_user(username='normaluser', password='password123')
+        assign_role(self.normal_user, 'penetration_tester')
+        
+        # Additional users for testing modifications
+        self.target_superuser = User.objects.create_superuser(username='target_super', password='password123')
+        self.target_user = User.objects.create_user(username='target_user', password='password123')
+        assign_role(self.target_user, 'penetration_tester')
 
-    def test_user_creation(self):
-        data = {
-            'username': 'newuser',
-            'password': 'newpassword',
-            'role': 'sys_admin'
-        }
-        response = self.client.post(
-            reverse('admin_interface_update') + '?mode=create',
-            data=json.dumps(data),
-            content_type='application/json'
-        )
+    def test_user_creation_permissions(self):
+        unique_username = f'newuser_{uuid.uuid4().hex[:8]}'
+        data = {'username': unique_username, 'password': 'newpass', 'role': 'penetration_tester'}
+        
+        # Test with superuser
+        self.client.force_login(self.superuser)
+        response = self.client.post(reverse('admin_interface_update') + '?mode=create',
+                                  data=data, content_type='application/json')
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(json.loads(response.content)['status'])
-        new_user = User.objects.get(username='newuser')
-        self.assertTrue(has_role(new_user, SysAdmin))
-
-    def test_user_not_found(self):
-        response = self.client.get(reverse('admin_interface_update') + '?user=999')
-        self.assertEqual(response.status_code, 404)
-        self.assertFalse(json.loads(response.content)['status'])
-
-    def test_get_request(self):
-        response = self.client.get(reverse('admin_interface_update') + f'?user={self.user_to_test.id}&mode=change_status')
+        
+        # Use new unique username for each test
+        unique_username = f'newuser_{uuid.uuid4().hex[:8]}'
+        data['username'] = unique_username
+        
+        # Test with sys_admin
+        self.client.force_login(self.sys_admin)
+        response = self.client.post(reverse('admin_interface_update') + '?mode=create',
+                                  data=data, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        
+        # Test with normal user
+        self.client.force_login(self.normal_user)
+        response = self.client.post(reverse('admin_interface_update') + '?mode=create',
+                                  data=data, content_type='application/json')
         self.assertEqual(response.status_code, 302)
 
-    def test_get_request_with_invalid_mode(self):
-        response = self.client.get(reverse('admin_interface_update') + f'?user={self.user_to_test.id}&mode=wrong_mode')
-        self.assertEqual(response.status_code, 400)
-
-    def test_post_request_update(self):
-        data = {
-            'role': 'penetration_tester',
-            'projects': []
-        }
-        response = self.client.post(
-            reverse('admin_interface_update') + f'?user={self.user_to_test.id}&mode=update',
-            data=json.dumps(data),
-            content_type='application/json'
-        )
+    def test_superuser_modification_permissions(self):
+        url = reverse('admin_interface_update') + f'?user={self.target_superuser.id}'
+        
+        # Test superuser modifying superuser
+        self.client.force_login(self.superuser)
+        initial_status = self.target_superuser.is_active
+        response = self.client.get(f'{url}&mode=change_status', follow=True)
+        self.target_superuser.refresh_from_db()
+        
+        # Check if the status has changed and we are redirected to admin_interface
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(json.loads(response.content)['status'])
-        self.user_to_test.refresh_from_db()
-        self.assertTrue(has_role(self.user_to_test, PenetrationTester))
-
-    def test_post_request_delete(self):
-        response = self.client.post(
-            reverse('admin_interface_update') + f'?user={self.user_to_test.id}&mode=delete',
-            content_type='application/json'
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(json.loads(response.content)['status'])
-        self.assertFalse(User.objects.filter(id=self.user_to_test.id).exists())
-
-    def test_invalid_method(self):
-        response = self.client.put(reverse('admin_interface_update') + f'?user={self.user_to_test.id}')
+        self.assertNotEqual(initial_status, self.target_superuser.is_active)
+        self.assertRedirects(response, reverse('admin_interface'))
+        
+        # Test sys_admin modifying superuser
+        self.client.force_login(self.sys_admin)
+        initial_status = self.target_superuser.is_active
+        response = self.client.get(f'{url}&mode=change_status')
+        self.target_superuser.refresh_from_db()
+        
+        # Check if the status has not changed and we have a 403
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(initial_status, self.target_superuser.is_active)
+        
+        # Test normal user modifying superuser
+        self.client.force_login(self.normal_user)
+        initial_status = self.target_superuser.is_active
+        response = self.client.get(f'{url}&mode=change_status')
+        self.target_superuser.refresh_from_db()
+        
+        # Check if the status has not changed and we have a 403
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(initial_status, self.target_superuser.is_active)
+
+    def test_user_modification_permissions(self):
+        url = reverse('admin_interface_update') + f'?user={self.target_user.id}'
+        
+        # Test superuser modifying normal user
+        self.client.force_login(self.superuser)
+        response = self.client.post(f'{url}&mode=update',
+                                  data={'role': 'auditor'}, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        
+        # Test sys_admin modifying normal user
+        self.client.force_login(self.sys_admin)
+        response = self.client.post(f'{url}&mode=update',
+                                  data={'role': 'penetration_tester'}, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        
+        # Test normal user modifying normal user
+        self.client.force_login(self.normal_user)
+        response = self.client.post(f'{url}&mode=update',
+                                  data={'role': 'auditor'}, content_type='application/json')
+        self.assertEqual(response.status_code, 302)
+
+    def test_self_modification_restrictions(self):
+        # Test superuser trying to delete themselves
+        self.client.force_login(self.superuser)
+        response = self.client.post(
+            reverse('admin_interface_update') + f'?user={self.superuser.id}&mode=delete')
+        self.assertEqual(response.status_code, 403)
+        
+        # Test sys_admin trying to delete themselves
+        self.client.force_login(self.sys_admin)
+        response = self.client.post(
+            reverse('admin_interface_update') + f'?user={self.sys_admin.id}&mode=delete')
+        self.assertEqual(response.status_code, 403)
 

--- a/web/dashboard/utils.py
+++ b/web/dashboard/utils.py
@@ -5,12 +5,14 @@ from django.urls import reverse
 from .models import Project
 
 def get_user_projects(user):
-    if user.is_superuser:
+    # Return all projects for superuser and sys_admin
+    if user.is_superuser or get_user_groups(user) == 'sys_admin':
         return Project.objects.all()
+    # Return only projects where user is a member
     return Project.objects.filter(users=user)
 
 def user_has_project_access_by_id(user, project_id):
-    if user.is_superuser:
+    if user.is_superuser or get_user_groups(user) == 'sys_admin':
         return Project.objects.all()
     try:
         project = Project.objects.get(id=project_id)
@@ -38,3 +40,13 @@ def user_has_project_access(view_func):
         return redirect(reverse('permission_denied'))
 
     return _wrapped_view
+
+def get_user_groups(user):
+    if user.is_superuser or user.groups.filter(name='sys_admin').exists():
+        return 'sys_admin'
+    elif user.groups.filter(name='auditor').exists():
+        return 'auditor'
+    elif user.groups.filter(name='penetration_tester').exists():
+        return 'penetration_tester'
+    else:
+        return 'unknown'

--- a/web/dashboard/utils.py
+++ b/web/dashboard/utils.py
@@ -11,15 +11,6 @@ def get_user_projects(user):
     # Return only projects where user is a member
     return Project.objects.filter(users=user)
 
-def user_has_project_access_by_id(user, project_id):
-    if user.is_superuser or get_user_groups(user) == 'sys_admin':
-        return Project.objects.all()
-    try:
-        project = Project.objects.get(id=project_id)
-        return project in get_user_projects(user)
-    except Project.DoesNotExist:
-        return False
-
 def user_has_project_access(view_func):
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -209,9 +209,9 @@ def admin_interface(request):
 def admin_interface_update(request):
     mode = request.GET.get('mode')
     method = request.method
+    target_user = get_user_from_request(request)
 
     if mode and mode != 'create':
-        target_user = get_user_from_request(request)
         if not target_user:
             return JsonResponse({'status': False, 'error': 'User ID not provided'}, status=404)
 

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -435,12 +435,9 @@ def onboarding(request):
                 NetlasAPIKey.objects.create(key=key_netlas)
 
     context['error'] = error
-    if request.user.is_superuser:
-        # if super user, redirect to the first project
-        project = Project.objects.first()
-    else:
-        # check is any projects exists for the current user
-        project = Project.objects.filter(users=request.user).first()
+
+    # Get first available project
+    project = get_user_projects(request.user).first()
 
     context['openai_key'] = OpenAiAPIKey.objects.first()
     context['netlas_key'] = NetlasAPIKey.objects.first()

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -425,7 +425,7 @@ def onboarding(request):
             )
         except Exception as e:
             logger.error(f' Could not create project, Error: {e}')
-            error = ' Could not create project, check logs for more details'
+            error = 'Could not create project, check logs for more details'
 
 
         try:
@@ -437,8 +437,8 @@ def onboarding(request):
                 )
                 assign_role(user, create_user_role)
         except Exception as e:
-            logger.error(f' Could not create User, Error: {e}')
-            error = ' Could not create User, check logs for more details'
+            logger.error(f'Could not create User, Error: {e}')
+            error = 'Could not create User, check logs for more details'
 
 
 

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -405,6 +405,7 @@ def delete_project(request, id):
     return JsonResponse(responseData)
 
 def onboarding(request):
+    error = ''
     if request.method == "POST":
         project_name = request.POST.get('project_name')
         slug = slugify(project_name)
@@ -416,7 +417,6 @@ def onboarding(request):
 
         insert_date = timezone.now()
 
-        error = ''
         try:
             Project.objects.create(
                 name=project_name,


### PR DESCRIPTION
Fix #241 

This change introduces several fixes to the `sys_admin` role. 
- Better check the project list to prevent new sys admins to be stucked on **Welcome** page
- Refines the permissions of the user administration actions to prevent `superuser` profile edition by `sys_admin`, only superuser can edit superuser
- Clarify user roles in the administrator interface.

  - [x] Test onboarding page after `sys_admin` creation
  - [x] Test permissions with each roles
