### PR TITLE
fix(install): hardcoded gid in celery and web containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 include .env
 .DEFAULT_GOAL:=help
 
+# Export GID (Group ID)
+export GID=$(shell id -g)
+
 # Define RENGINE_VERSION
 RENGINE_VERSION := $(shell cat web/reNgine/version.txt)
 export RENGINE_VERSION
@@ -48,7 +51,7 @@ images:			## Show all Docker images for reNgine services.
 
 build:			## Build all Docker images locally.
 	@make remove_images
-	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_BUILD} build ${SERVICES}
+	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_BUILD} build --build-arg GID=$(GID) ${SERVICES}
 
 build_up:		## Build and start all services.
 	@make down

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -10,6 +10,7 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
+ARG GID
 
 RUN apt update -y && apt install -y      \
     build-essential     \
@@ -41,9 +42,9 @@ RUN fc-cache -f && \
     fc-list | sort
 
 ENV USERNAME="rengine"
-RUN addgroup --gid 1000 --system $USERNAME && \
+RUN addgroup --gid $GID --system $USERNAME && \
     mkdir -p /home/$USERNAME && \
-    adduser --gid 1000 --system --shell /bin/false --disabled-password --uid 1000 --home /home/$USERNAME $USERNAME && \
+    adduser --gid $GID --system --shell /bin/false --disabled-password --uid $GID --home /home/$USERNAME $USERNAME && \
     chown $USERNAME:$USERNAME /home/$USERNAME
 
 # Download and install geckodriver

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -6,10 +6,16 @@ services:
     build: ./redis
 
   celery:
-    build: ./celery
+    build:
+      context: ./celery
+      args:
+        GID: ${GID}
 
   web:
-    build: ./web
+    build:
+      context: ./web
+      args:
+        GID: ${GID}
 
   proxy:
     build: ./proxy

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -10,14 +10,15 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
+ARG GID
 
 RUN apk add --no-cache bash postgresql-libs curl fontconfig ttf-freefont font-noto terminus-font net-tools htop vim && \
     apk add --no-cache py3-pip gcc musl-dev python3-dev pango zlib-dev jpeg-dev openjpeg-dev g++ libffi-dev && \
     apk add --no-cache --virtual .build-deps gcc python3-dev musl-dev postgresql-dev && \
     fc-cache -f && \ 
     fc-list | sort && \
-    addgroup --gid 1000 -S $USERNAME && \
-    adduser -g 1000 -u 1000 -S --shell /bin/bash --ingroup $USERNAME $USERNAME
+    addgroup --gid $GID -S $USERNAME && \
+    adduser -g $GID -u $GID -S --shell /bin/bash --ingroup $USERNAME $USERNAME
 
 USER $USERNAME
 ENV PATH=/home/$USERNAME/.local/bin:${PATH}


### PR DESCRIPTION
Fix #252 

This PR resolves issue #252 by dynamically determining the GID for the web and celery containers, replacing the hardcoded GID (1000) with a more flexible approach. This change ensures compatibility in environments where the GID differs from 1000.

## Summary by Sourcery

Set the GID of the `web` and `celery` containers dynamically at build time using an argument passed to the `docker-compose` command.

Enhancements:
- Use the provided GID to create the `rengine` user and group in the `web` and `celery` containers instead of the hardcoded value 1000.

Build:
- Pass the host's group ID (GID) to the `web` and `celery` Docker builds as a build argument.