### PR TITLE
build(makefile): correctly retrieve user GID even when using sudo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,9 @@ jobs:
           context: ./docker/${{ matrix.image }}
           file: ./docker/${{ matrix.image }}/Dockerfile
           push: ${{ github.event_name != 'pull_request' || github.event.inputs.push_image == 'true' }}
+          build-args: |
+            HOST_UID=1000
+            HOST_GID=1000
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ MANIFEST
 # IDE files
 .vscode/settings.json
 .vscode/tasks-and-contexts.json
+.idea/
 
 *.manifest
 *.spec

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include .env
 .DEFAULT_GOAL:=help
 
 # Export GID (Group ID)
-export GID=$(shell id -g)
+export GID=$(shell id -g $(SUDO_USER))
 
 # Define RENGINE_VERSION
 RENGINE_VERSION := $(shell cat web/reNgine/version.txt)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 include .env
 .DEFAULT_GOAL:=help
 
-# Export GID (Group ID)
-export GID=$(if $(SUDO_USER),$(shell id -g $(SUDO_USER)),$(shell id -g))
+# Export host UID & GID
+export HOST_UID=$(if $(SUDO_USER),$(shell id -u $(SUDO_USER)),$(shell id -u))
+export HOST_GID=$(if $(SUDO_USER),$(shell id -g $(SUDO_USER)),$(shell id -g))
+
 
 # Define RENGINE_VERSION
 RENGINE_VERSION := $(shell cat web/reNgine/version.txt)
@@ -55,7 +57,7 @@ images:			## Show all Docker images for reNgine services.
 
 build:			## Build all Docker images locally.
 	@make remove_images
-	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_BUILD} build --build-arg GID=$(GID) ${SERVICES}
+	${DOCKER_COMPOSE_FILE_CMD} -f ${COMPOSE_FILE_BUILD} build --build-arg HOST_UID=$(HOST_UID) --build-arg HOST_GID=$(HOST_GID) ${SERVICES}
 
 build_up:		## Build and start all services.
 	@make down

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include .env
 .DEFAULT_GOAL:=help
 
 # Export GID (Group ID)
-export GID=$(shell id -g $(SUDO_USER))
+export GID=$(if $(SUDO_USER),$(shell id -g $(SUDO_USER)),$(shell id -g))
 
 # Define RENGINE_VERSION
 RENGINE_VERSION := $(shell cat web/reNgine/version.txt)

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -10,7 +10,8 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
-ARG GID
+ARG HOST_UID
+ARG HOST_GID
 
 RUN apt update -y && apt install -y      \
     build-essential     \
@@ -42,9 +43,9 @@ RUN fc-cache -f && \
     fc-list | sort
 
 ENV USERNAME="rengine"
-RUN addgroup --gid $GID --system $USERNAME && \
+RUN addgroup --gid $HOST_GID --system $USERNAME && \
     mkdir -p /home/$USERNAME && \
-    adduser --gid $GID --system --shell /bin/false --disabled-password --uid $GID --home /home/$USERNAME $USERNAME && \
+    adduser --gid $HOST_GID --system --shell /bin/false --disabled-password --uid $HOST_UID --home /home/$USERNAME $USERNAME && \
     chown $USERNAME:$USERNAME /home/$USERNAME
 
 # Download and install geckodriver

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -9,13 +9,15 @@ services:
     build:
       context: ./celery
       args:
-        GID: ${GID}
+        HOST_UID: ${HOST_UID}
+        HOST_GID: ${HOST_GID}
 
   web:
     build:
       context: ./web
       args:
-        GID: ${GID}
+        HOST_UID: ${HOST_UID}
+        HOST_GID: ${HOST_GID}
 
   proxy:
     build: ./proxy

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -10,15 +10,16 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
-ARG GID
+ARG HOST_UID
+ARG HOST_GID
 
 RUN apk add --no-cache bash postgresql-libs curl fontconfig ttf-freefont font-noto terminus-font net-tools htop vim && \
     apk add --no-cache py3-pip gcc musl-dev python3-dev pango zlib-dev jpeg-dev openjpeg-dev g++ libffi-dev && \
     apk add --no-cache --virtual .build-deps gcc python3-dev musl-dev postgresql-dev && \
     fc-cache -f && \ 
     fc-list | sort && \
-    addgroup --gid $GID -S $USERNAME && \
-    adduser -g $GID -u $GID -S --shell /bin/bash --ingroup $USERNAME $USERNAME
+    addgroup --gid $HOST_GID -S $USERNAME && \
+    adduser -g $HOST_GID -u $HOST_UID -S --shell /bin/bash --ingroup $USERNAME $USERNAME
 
 USER $USERNAME
 ENV PATH=/home/$USERNAME/.local/bin:${PATH}

--- a/install.sh
+++ b/install.sh
@@ -236,27 +236,46 @@ main() {
   check_docker
   check_docker_compose
 
-  if [ $isNonInteractive = false ]; then
-    log "Do you want to build Docker images from source or use pre-built images (recommended)? \nThis saves significant build time but requires good download speeds for it to complete fast." $COLOR_RED
-    log "1) From source" $COLOR_YELLOW
-    log "2) Use pre-built images (default)" $COLOR_YELLOW
-    read -p "Enter your choice (1 or 2, default is 2): " choice
+if [ -n "$SUDO_USER" ]; then
+    current_id=$(id -u "$SUDO_USER")
+else
+    current_id=$(id -u)
+fi
 
-    case $choice in
-        1)
-            INSTALL_TYPE="source"
-            ;;
-        2|"")
-            INSTALL_TYPE="prebuilt"
-            ;;
-        *)
-            log "Invalid choice. Defaulting to pre-built images." $COLOR_RED
-            INSTALL_TYPE="prebuilt"
-            ;;
-    esac
+if [ "$current_id" -ne 1000 ]; then
+    INSTALL_TYPE="source"
+    log "Build has been forced because your user ID is not the same as the pre-built images. If you want to use pre-built images, your current user installing reNgine-ng must be 1000." $COLOR_RED
+else
+    if [ $isNonInteractive = false ]; then
+        log "Do you want to build Docker images from source or use pre-built images (recommended)? \nThis saves significant build time but requires good download speeds for it to complete fast." $COLOR_RED
+        log "1) From source" $COLOR_YELLOW
+        log "2) Use pre-built images (default)" $COLOR_YELLOW
+        read -p "Enter your choice (1 or 2, default is 2): " choice
 
-    log "Selected installation type: $INSTALL_TYPE" $COLOR_CYAN
-  fi
+        case $choice in
+            1)
+                INSTALL_TYPE="source"
+                ;;
+            2|"")
+                INSTALL_TYPE="prebuilt"
+                ;;
+            *)
+                log "Invalid choice. Defaulting to pre-built images." $COLOR_RED
+                INSTALL_TYPE="prebuilt"
+                ;;
+        esac
+    fi
+fi
+
+if [ -z "$INSTALL_TYPE" ]; then
+    log "Error: INSTALL_TYPE is not set" $COLOR_RED
+    exit 1
+elif [ "$INSTALL_TYPE" != "prebuilt" ] && [ "$INSTALL_TYPE" != "source" ]; then
+    log "Error: INSTALL_TYPE must be either 'prebuilt' or 'source'" $COLOR_RED
+    exit 1
+fi
+
+log "Selected installation type: $INSTALL_TYPE" $COLOR_CYAN
 
   # Non-interactive install
   if [ $isNonInteractive = true ]; then


### PR DESCRIPTION
Fix #253 

Updated the GID export in the `Makefile` to ensure it retrieves the group ID of the original user, even when using sudo.

## Reason for the Change
Previously, when running the Makefile with sudo, the id -g command would return the GID of the root user instead of the actual user's GID. This could cause permission issues, especially when mounting files or working with containers that rely on the correct GID for volume mapping.

## Impact
Ensures that the correct user GID is used in all scenarios, even with sudo.

## Summary by Sourcery

Build:
- Update the Makefile to retrieve the correct user GID even when using sudo.