### PR TITLE
fix: reset Celery Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image: [celery, web, postgres, redis, ollama, certs, proxy]
@@ -91,7 +91,7 @@ jobs:
   update-release:
     needs: build-and-push
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -11,6 +11,12 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
 
+RUN apt update -y && apt install -y \
+    gcc-11 \
+    g++-11 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+
 RUN apt update -y && apt install -y      \
     build-essential     \
     zlib1g-dev          \
@@ -82,11 +88,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
     fi
 
 # Install python 3.10
-RUN cd /root && wget https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tgz && \
-    tar -xvf Python-3.10.0.tgz && \
-    rm Python-3.10.0.tgz && \
-    cd Python-3.10.0 && \
-    ./configure && \
+RUN cd /root && wget https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz && \
+    tar -xvf Python-3.10.13.tgz && \
+    rm Python-3.10.13.tgz && \
+    cd Python-3.10.13 && \
+    ./configure --enable-optimmizations && \
     make -j4 && \
     make altinstall
 

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -10,12 +10,8 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
-
-RUN apt update -y && apt install -y \
-    gcc-11 \
-    g++-11 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+ARG HOST_UID
+ARG HOST_GID
 
 RUN apt update -y && apt install -y      \
     build-essential     \
@@ -47,9 +43,9 @@ RUN fc-cache -f && \
     fc-list | sort
 
 ENV USERNAME="rengine"
-RUN addgroup --gid 1000 --system $USERNAME && \
+RUN addgroup --gid $HOST_GID --system $USERNAME && \
     mkdir -p /home/$USERNAME && \
-    adduser --gid 1000 --system --shell /bin/false --disabled-password --uid 1000 --home /home/$USERNAME $USERNAME && \
+    adduser --gid $HOST_GID --system --shell /bin/false --disabled-password --uid $HOST_UID --home /home/$USERNAME $USERNAME && \
     chown $USERNAME:$USERNAME /home/$USERNAME
 
 # Download and install geckodriver
@@ -88,11 +84,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
     fi
 
 # Install python 3.10
-RUN cd /root && wget https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz && \
-    tar -xvf Python-3.10.13.tgz && \
-    rm Python-3.10.13.tgz && \
-    cd Python-3.10.13 && \
-    ./configure --enable-optimmizations && \
+RUN cd /root && wget https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tgz && \
+    tar -xvf Python-3.10.0.tgz && \
+    rm Python-3.10.0.tgz && \
+    cd Python-3.10.0 && \
+    ./configure --enable-optimizations && \
     make -j4 && \
     make altinstall
 

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -86,7 +86,7 @@ RUN cd /root && wget https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tgz 
     tar -xvf Python-3.10.0.tgz && \
     rm Python-3.10.0.tgz && \
     cd Python-3.10.0 && \
-    ./configure --enable-optimizations && \
+    ./configure && \
     make -j4 && \
     make altinstall
 

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -10,8 +10,6 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV USERNAME="rengine"
-ARG HOST_UID
-ARG HOST_GID
 
 RUN apt update -y && apt install -y      \
     build-essential     \
@@ -43,9 +41,9 @@ RUN fc-cache -f && \
     fc-list | sort
 
 ENV USERNAME="rengine"
-RUN addgroup --gid $HOST_GID --system $USERNAME && \
+RUN addgroup --gid 1000 --system $USERNAME && \
     mkdir -p /home/$USERNAME && \
-    adduser --gid $HOST_GID --system --shell /bin/false --disabled-password --uid $HOST_UID --home /home/$USERNAME $USERNAME && \
+    adduser --gid 1000 --system --shell /bin/false --disabled-password --uid 1000 --home /home/$USERNAME $USERNAME && \
     chown $USERNAME:$USERNAME /home/$USERNAME
 
 # Download and install geckodriver
@@ -114,17 +112,17 @@ RUN ARCH=$(dpkg --print-architecture) \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/tomnomnom/gf@dcd4c361f9f5ba302294ed38b8ce278e8ba69006 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/tomnomnom/unfurl@v0.4.3 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/tomnomnom/waybackurls@v0.1.0 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/httpx/cmd/httpx@v1.6.9 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.6.7 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.5 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.3.2 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/httpx/cmd/httpx@v1.6.0 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.6.6 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.2.6 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.3.0 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/hakluke/hakrawler@latest \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/lc/gau/v2/cmd/gau@v2.2.4 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/lc/gau/v2/cmd/gau@v2.2.1 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/owasp-amass/amass/v4/...@v4.2.0 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/ffuf/ffuf/v2@v2.1.0 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/tlsx/cmd/tlsx@v1.1.8 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/hahwul/dalfox/v2@v2.9.3 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/katana/cmd/katana@v1.1.1 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/tlsx/cmd/tlsx@v1.1.6 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/hahwul/dalfox/v2@v2.9.2 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/katana/cmd/katana@v1.1.0 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@v1.4.1 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/sa7mon/s3scanner@c544f1cf00f70cae3f2155b24d336f515b7c598b \
         && chmod 700 -R $GOPATH/pkg/* \
@@ -179,14 +177,12 @@ RUN cd $TOOLPATH/.github/OneForAll && mv /home/$USERNAME/oneforall-pyproject.tom
     cd /home/$USERNAME && poetry install
 
 # Create tools config files
-RUN nuclei -silent && naabu -version && subfinder -version && \
-    mkdir -p /home/$USERNAME/.config/theHarvester && \
-    mkdir -p /home/$USERNAME/.config/amass && \
-    mkdir -p /home/$USERNAME/.config/gau
+RUN nuclei -silent && naabu -version && subfinder -version && mkdir -p /home/$USERNAME/.config/theHarvester
 COPY --chown=$USERNAME:$USERNAME ./config/the-harvester-api-keys.yaml /home/$USERNAME/.config/theHarvester/api-keys.yaml
-COPY --chown=$USERNAME:$USERNAME ./config/amass.ini /home/$USERNAME/.config/amass/config.ini
-COPY --chown=$USERNAME:$USERNAME ./config/gau.toml /home/$USERNAME/.config/gau/config.toml
-RUN ln -s /home/$USERNAME/.config/theHarvester /home/$USERNAME/.theHarvester
+COPY --chown=$USERNAME:$USERNAME ./config/amass.ini /home/$USERNAME/.config/amass.ini
+COPY --chown=$USERNAME:$USERNAME ./config/.gau.toml /home/$USERNAME/.config/.gau.toml
+RUN ln -s /home/$USERNAME/.config/.gau.toml /home/$USERNAME/.gau.toml
+
 COPY ./entrypoint.sh /entrypoint.sh
 RUN mkdir -p /home/$USERNAME/rengine /home/$USERNAME/scan_results \
     && chown -R $USERNAME:$USERNAME /home/$USERNAME/rengine \

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -112,17 +112,17 @@ RUN ARCH=$(dpkg --print-architecture) \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/tomnomnom/gf@dcd4c361f9f5ba302294ed38b8ce278e8ba69006 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/tomnomnom/unfurl@v0.4.3 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/tomnomnom/waybackurls@v0.1.0 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/httpx/cmd/httpx@v1.6.0 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.6.6 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.2.6 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.3.0 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/httpx/cmd/httpx@v1.6.9 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.6.7 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.5 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.3.2 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/hakluke/hakrawler@latest \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/lc/gau/v2/cmd/gau@v2.2.1 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/lc/gau/v2/cmd/gau@v2.2.4 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/owasp-amass/amass/v4/...@v4.2.0 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/ffuf/ffuf/v2@v2.1.0 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/tlsx/cmd/tlsx@v1.1.6 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/hahwul/dalfox/v2@v2.9.2 \
-        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/katana/cmd/katana@v1.1.0 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/tlsx/cmd/tlsx@v1.1.8 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/hahwul/dalfox/v2@v2.9.3 \
+        && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/projectdiscovery/katana/cmd/katana@v1.1.1 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@v1.4.1 \
         && GOARCH=$ARCH go install -ldflags="-s -w" -v github.com/sa7mon/s3scanner@c544f1cf00f70cae3f2155b24d336f515b7c598b \
         && chmod 700 -R $GOPATH/pkg/* \
@@ -177,12 +177,14 @@ RUN cd $TOOLPATH/.github/OneForAll && mv /home/$USERNAME/oneforall-pyproject.tom
     cd /home/$USERNAME && poetry install
 
 # Create tools config files
-RUN nuclei -silent && naabu -version && subfinder -version && mkdir -p /home/$USERNAME/.config/theHarvester
+RUN nuclei -silent && naabu -version && subfinder -version && \
+    mkdir -p /home/$USERNAME/.config/theHarvester && \
+    mkdir -p /home/$USERNAME/.config/amass && \
+    mkdir -p /home/$USERNAME/.config/gau
 COPY --chown=$USERNAME:$USERNAME ./config/the-harvester-api-keys.yaml /home/$USERNAME/.config/theHarvester/api-keys.yaml
-COPY --chown=$USERNAME:$USERNAME ./config/amass.ini /home/$USERNAME/.config/amass.ini
-COPY --chown=$USERNAME:$USERNAME ./config/.gau.toml /home/$USERNAME/.config/.gau.toml
-RUN ln -s /home/$USERNAME/.config/.gau.toml /home/$USERNAME/.gau.toml
-
+COPY --chown=$USERNAME:$USERNAME ./config/amass.ini /home/$USERNAME/.config/amass/config.ini
+COPY --chown=$USERNAME:$USERNAME ./config/gau.toml /home/$USERNAME/.config/gau/config.toml
+RUN ln -s /home/$USERNAME/.config/theHarvester /home/$USERNAME/.theHarvester
 COPY ./entrypoint.sh /entrypoint.sh
 RUN mkdir -p /home/$USERNAME/rengine /home/$USERNAME/scan_results \
     && chown -R $USERNAME:$USERNAME /home/$USERNAME/rengine \


### PR DESCRIPTION
Just to test image build action
No need to review

## Summary by Sourcery

Build:
- Update the Celery Dockerfile to pin several Go tools to specific versions, including httpx v1.6.0, subfinder v2.6.6, nuclei v3.2.6, naabu v2.3.0, gau v2.2.1, amass v4.2.0, ffuf v2.1.0, tlsx v1.1.6, dalfox v2.9.2, and katana v1.1.0.