### PR TITLE
build(ci): version-pin GitHub Runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image: [celery, web, postgres, redis, ollama, certs, proxy]
@@ -91,7 +91,7 @@ jobs:
   update-release:
     needs: build-and-push
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
+++ b/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   close-related-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.merged == true && startsWith(github.ref, 'refs/heads/release/')
     permissions:
       issues: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ 'ubuntu-latest' }}
+    runs-on: ${{ 'ubuntu-22.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   delete-untagged-ghcr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Pin GitHub Actions runner to `ubuntu-22.04` in all workflows.