### PR TITLE
build(docker): add missing geoiplookup command

### DIFF
--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -35,6 +35,7 @@ RUN apt update -y && apt install -y      \
     gettext             \
     nmap                \
     net-tools           \
+    geoip-bin           \
     htop                \
     firefox-esr         \
     fontconfig fonts-freefont-ttf fonts-noto fonts-terminus


### PR DESCRIPTION
fix #257 

geoiplookup installation in celery docker

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where the `geoiplookup` command was missing in the Celery Docker image.