### PR TITLE
fix(bulk_delete_vulnerabilities): pass delete API endpoint Url

### DIFF
--- a/web/templates/base/_items/vulnerability_tab_content.html
+++ b/web/templates/base/_items/vulnerability_tab_content.html
@@ -36,7 +36,7 @@
 						<div class="btn-group mb-2 float-start dropstart">
 							<button id="bulk_delete_vulnerabilities" class="btn btn-soft-danger ms-1 vulnerability_btns disabled" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Bulk Delete Vulnerabilities" data-url="/api/action/vulnerability/delete/">
 								<i class="fe-regular fe-trash"></i>
-								<span>Bulk Delete Vulneraties<span>
+								<span>Bulk Delete vulnerabilities<span>
 							</button>
 						</div>
 						<div class="btn-group mb-2 float-end dropstart">

--- a/web/templates/base/_items/vulnerability_tab_content.html
+++ b/web/templates/base/_items/vulnerability_tab_content.html
@@ -34,7 +34,7 @@
 							</button>
 						</div>
 						<div class="btn-group mb-2 float-start dropstart">
-							<button id="bulk_delete_vulnerabilities" class="btn btn-soft-danger ms-1 vulnerability_btns disabled" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Bulk Delete Vulnerabilities" data-url="/api/action/vulnerability/delete/">
+							<button id="bulk_delete_vulnerabilities" class="btn btn-soft-danger ms-1 vulnerability_btns disabled" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Bulk Delete Vulnerabilities" data-url="{% url 'api:delete_vulnerability' %}" >
 								<i class="fe-regular fe-trash"></i>
 								<span>Bulk Delete vulnerabilities<span>
 							</button>

--- a/web/templates/base/_items/vulnerability_tab_content.html
+++ b/web/templates/base/_items/vulnerability_tab_content.html
@@ -34,7 +34,7 @@
 							</button>
 						</div>
 						<div class="btn-group mb-2 float-start dropstart">
-							<button id="bulk_delete_vulnerabilities" class="btn btn-soft-danger ms-1 vulnerability_btns disabled" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Bulk Delete Vulnerabilities">
+							<button id="bulk_delete_vulnerabilities" class="btn btn-soft-danger ms-1 vulnerability_btns disabled" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Bulk Delete Vulnerabilities" data-url="/api/action/vulnerability/delete/">
 								<i class="fe-regular fe-trash"></i>
 								<span>Bulk Delete Vulneraties<span>
 							</button>


### PR DESCRIPTION
Fix #260 

### Bug : 
- When a user clicks on 'Bulk delete vulnerabilities' swal shows a loading alert and nothing happens (even after refreching the page)

### Fix details : 
- I  added the API endpoint Url to 'bulk delete vulnerabilities' button in vulnerability_tab_content.html and it fixed the issue.
-  It didn't have it before and it was sending the datat to /undefined which doesn't exist (as shown in screenshot down below)
![image](https://github.com/user-attachments/assets/604b0635-0ad8-4993-bb8c-157dbe26af97)

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where clicking "Bulk delete vulnerabilities" did nothing.