### PR TITLE
chore(issue-template): add issue template for CI/CD

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci.yml
+++ b/.github/ISSUE_TEMPLATE/ci.yml
@@ -1,0 +1,38 @@
+name: 🛠️ CI/CD
+description: File a feature request or bug-report for CI/CD
+title: "ci(scope): "
+labels: ["ci"]
+body:
+- type: textarea
+  attributes:
+    label: Expected feature
+    description: A clear and concise description of what the problem is and how it could be approached.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Alternative solutions
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false
+- type: checkboxes
+  id: acknowledgements
+  attributes:
+    label: Acknowledgements
+    description: Your bug report will be closed if you don't follow the checklist below.
+    options:
+      - label: This issue is not a duplicate of an existing bug report.
+        required: true
+      - label: I have chosen an appropriate title.
+        required: true
+      - label: All requested information has been provided properly.
+        required: true


### PR DESCRIPTION
This is a good start I guess, but I'm open for feedback. Should it be more extensive or should we keep it simple? I'm targeting `master` because we'll need it right away; not necessarily with 2.1.1 and onwards.

## Summary by Sourcery

Chores:
- Add an issue template for CI/CD related issues, including sections for expected features, alternative solutions, and acknowledgements to ensure complete bug reports