### PR TITLE
build(release): add text to generated changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -19,3 +19,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          body: "Make sure you have read our [breaking changes](https://github.com/Security-Tools-Alliance/rengine-ng/wiki/Installation#breaking-changes) and [how to update](https://github.com/Security-Tools-Alliance/rengine-ng/wiki/Installation#-updating-rengine-ng). The changelog is as follows:"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the release workflow to run on `ubuntu-22.04` and prepend generated changelogs with a message about breaking changes and update instructions