### PR TITLE
ci(release): split up labels into different titles in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,9 +6,15 @@ changelog:
     - title: Fixed
       labels:
         - bug
-    - title: Miscellaneous
+    - title: Refactored
       labels:
         - refactor
+    - title: Dependencies
+      labels:
         - dependencies
-        - documentation
+    - title: CI/CD
+      labels:
         - ci
+    - title: documentation
+      labels:
+        - documentation


### PR DESCRIPTION
Refactored the changelog section in .github/release.yml to add new categories for dependencies and CI/CD, and clarified label associations for documentation and refactor changes.

## Summary by Sourcery

Organize the release changelog into clearer categories by replacing the Miscellaneous section with separate Refactored, Dependencies, CI/CD, and Documentation titles and aligning labels accordingly.

Enhancements:
- Rename the 'Miscellaneous' changelog title to 'Refactored'.
- Introduce separate 'Dependencies', 'CI/CD', and 'Documentation' changelog categories with corresponding labels.

Build:
- Update .github/release.yml to split up changelog labels into distinct sections.