### PR TITLE
build(ci): close all linked issues on PR merge to release branch

### DIFF
--- a/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
+++ b/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
@@ -11,15 +11,84 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.ref, 'refs/heads/release/')
     permissions:
       issues: write
+      contents: read
     steps:
-      - name: Extract issue number
-        id: extract_issue_number
+      - name: Extract and close all linked issues
         run: |
-          issue_number=$(echo "${{ github.event.pull_request.body }}" | grep -oE '#[0-9]+' | head -n 1 | tr -d '#')
-          echo "ISSUE_NUMBER=$issue_number" >> $GITHUB_ENV
-
-      - name: Close linked issues
-        uses: peter-evans/close-issue@v3
-        with:
-          issue-number: ${{ env.ISSUE_NUMBER }}
-          comment: "This issue is being closed because the related PR has been merged into a release branch."
+          # Get linked issues using GitHub's GraphQL API
+          # This matches exactly what GitHub shows in "Successfully merging this pull request may close these issues"
+          
+          echo "Fetching GitHub-linked issues..."
+          
+          # Use GraphQL to get the exact same data GitHub shows in the UI
+          linked_issues=$(curl -s -X POST \
+            -H "Accept: application/vnd.github.v4+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{
+              "query": "query($owner: String!, $repo: String!, $number: Int!) { 
+                repository(owner: $owner, name: $repo) { 
+                  pullRequest(number: $number) { 
+                    closingIssuesReferences(first: 100) { 
+                      nodes { 
+                        number 
+                      } 
+                    } 
+                  } 
+                } 
+              }",
+              "variables": {
+                "owner": "${{ github.repository_owner }}",
+                "repo": "${{ github.event.repository.name }}",
+                "number": ${{ github.event.pull_request.number }}
+              }
+            }' \
+            https://api.github.com/graphql)
+          
+          # Extract issue numbers from GraphQL response
+          issue_numbers=$(echo "$linked_issues" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[].number // empty' | sort -u)
+          
+          if [ -z "$issue_numbers" ]; then
+            echo "No linked issues found that would be closed by GitHub's automatic linking"
+            exit 0
+          fi
+          
+          echo "Found GitHub-linked issues: $issue_numbers"
+          
+          # Close each issue individually
+          for issue_number in $issue_numbers; do
+            if [ -n "$issue_number" ]; then
+              echo "Closing issue #$issue_number"
+              
+              # Close the issue
+              close_response=$(curl -s -w "%{http_code}" -X PATCH \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number" \
+                -d '{"state":"closed"}')
+              
+              close_http_code="${close_response: -3}"
+              
+              if [ "$close_http_code" = "200" ]; then
+                echo "✅ Successfully closed issue #$issue_number"
+                
+                # Add a comment to explain why the issue was closed
+                comment_response=$(curl -s -w "%{http_code}" -X POST \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number/comments" \
+                  -d "{\"body\":\"This issue is being closed because the related PR #${{ github.event.pull_request.number }} has been merged into a release branch.\"}")
+                
+                comment_http_code="${comment_response: -3}"
+                
+                if [ "$comment_http_code" = "201" ]; then
+                  echo "✅ Added comment to issue #$issue_number"
+                else
+                  echo "⚠️ Failed to add comment to issue #$issue_number (HTTP $comment_http_code)"
+                fi
+              else
+                echo "❌ Failed to close issue #$issue_number (HTTP $close_http_code)"
+              fi
+            fi
+          done

--- a/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
+++ b/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
@@ -20,8 +20,14 @@ jobs:
           
           echo "Fetching GitHub-linked issues..."
           
+          # Check if jq is installed
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "Error: jq is not installed. Please install jq to run this script."
+            exit 1
+          fi
+          
           # Use GraphQL to get the exact same data GitHub shows in the UI
-          linked_issues=$(curl -s -X POST \
+          graphql_response=$(curl -s -X POST \
             -H "Accept: application/vnd.github.v4+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -d '{
@@ -44,8 +50,21 @@ jobs:
             }' \
             https://api.github.com/graphql)
           
+          # Check for GraphQL errors or malformed response
+          if ! echo "$graphql_response" | jq . >/dev/null 2>&1; then
+            echo "Error: Malformed JSON response from GitHub GraphQL API"
+            echo "$graphql_response"
+            exit 1
+          fi
+
+          if [ "$(echo "$graphql_response" | jq '.errors')" != "null" ]; then
+            echo "Error(s) returned from GitHub GraphQL API:"
+            echo "$graphql_response" | jq '.errors'
+            exit 1
+          fi
+          
           # Extract issue numbers from GraphQL response
-          issue_numbers=$(echo "$linked_issues" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[].number // empty' | sort -u)
+          issue_numbers=$(echo "$graphql_response" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[].number // empty' | sort -u)
           
           if [ -z "$issue_numbers" ]; then
             echo "No linked issues found that would be closed by GitHub's automatic linking"
@@ -59,36 +78,46 @@ jobs:
             if [ -n "$issue_number" ]; then
               echo "Closing issue #$issue_number"
               
-              # Close the issue
-              close_response=$(curl -s -w "%{http_code}" -X PATCH \
+              # Close the issue using robust HTTP response handling
+              close_tmpfile=$(mktemp)
+              close_headers=$(mktemp)
+              curl -s -D "$close_headers" -o "$close_tmpfile" -X PATCH \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number" \
-                -d '{"state":"closed"}')
-              
-              close_http_code="${close_response: -3}"
-              
+                -d '{"state":"closed"}'
+
+              close_http_code=$(awk 'NR==1 {print $2}' "$close_headers")
+
               if [ "$close_http_code" = "200" ]; then
                 echo "✅ Successfully closed issue #$issue_number"
                 
-                # Add a comment to explain why the issue was closed
-                comment_response=$(curl -s -w "%{http_code}" -X POST \
+                # Add a comment to explain why the issue was closed using robust HTTP response handling
+                comment_tmpfile=$(mktemp)
+                comment_headers=$(mktemp)
+                curl -s -D "$comment_headers" -o "$comment_tmpfile" -X POST \
                   -H "Accept: application/vnd.github.v3+json" \
                   -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
                   "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number/comments" \
-                  -d "{\"body\":\"This issue is being closed because the related PR #${{ github.event.pull_request.number }} has been merged into a release branch.\"}")
-                
-                comment_http_code="${comment_response: -3}"
-                
+                  -d "{\"body\":\"This issue is being closed because the related PR #${{ github.event.pull_request.number }} has been merged into a release branch.\"}"
+
+                comment_http_code=$(awk 'NR==1 {print $2}' "$comment_headers")
+
                 if [ "$comment_http_code" = "201" ]; then
                   echo "✅ Added comment to issue #$issue_number"
                 else
                   echo "⚠️ Failed to add comment to issue #$issue_number (HTTP $comment_http_code)"
                 fi
+                
+                # Clean up comment temp files
+                rm -f "$comment_tmpfile" "$comment_headers"
               else
                 echo "❌ Failed to close issue #$issue_number (HTTP $close_http_code)"
               fi
+              
+              # Clean up close temp files
+              rm -f "$close_tmpfile" "$close_headers"
             fi
           done


### PR DESCRIPTION
This pull request significantly improves the workflow for automatically closing issues linked to pull requests merged into a release branch. Instead of only closing a single issue referenced in the PR body, the workflow now accurately identifies and closes all issues that GitHub would automatically link and close, matching the UI behavior. It uses the GitHub GraphQL API for robust detection and includes better error handling and feedback.

**Automation improvements:**

* Replaces the previous approach of extracting a single issue number from the PR body with a script that uses GitHub's GraphQL API to fetch all issues linked to the pull request (i.e., those shown in the UI as "will be closed by this PR"), ensuring all relevant issues are targeted.
* Adds robust error handling for API responses, including checks for malformed JSON, GraphQL errors, and HTTP response codes when closing issues and adding comments.

**Workflow enhancements:**

* Iterates over all detected linked issues, closing each one individually and adding a comment explaining the closure, with clear success/failure messaging for each operation.
* Adds a check for the presence of the `jq` utility, providing a clear error message if it's missing.
* Updates workflow permissions to include `contents: read`, which may be required for some API calls. (F1798e