### PR TITLE
ci(auto-close-issues): fix auto closing issues not working

### DIFF
--- a/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
+++ b/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
@@ -8,13 +8,23 @@ on:
 jobs:
   close-related-issues:
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.merged == true && startsWith(github.ref, 'refs/heads/release/')
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.base.ref, 'release/')
     permissions:
       issues: write
       contents: read
     steps:
       - name: Extract and close all linked issues
         run: |
+          # Debug information
+          echo "=== Debug Information ==="
+          echo "PR Number: ${{ github.event.pull_request.number }}"
+          echo "Source Branch: ${{ github.event.pull_request.head.ref }}"
+          echo "Target Branch: ${{ github.event.pull_request.base.ref }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Repository Owner: ${{ github.repository_owner }}"
+          echo "Repository Name: ${{ github.event.repository.name }}"
+          echo "========================="
+          
           # Get linked issues using GitHub's GraphQL API
           # This matches exactly what GitHub shows in "Successfully merging this pull request may close these issues"
           
@@ -50,6 +60,9 @@ jobs:
             }' \
             https://api.github.com/graphql)
           
+          # Debug: Show the raw GraphQL response
+          echo "GraphQL Response: $graphql_response"
+          
           # Check for GraphQL errors or malformed response
           if ! echo "$graphql_response" | jq . >/dev/null 2>&1; then
             echo "Error: Malformed JSON response from GitHub GraphQL API"
@@ -63,12 +76,31 @@ jobs:
             exit 1
           fi
           
-          # Extract issue numbers from GraphQL response
-          issue_numbers=$(echo "$graphql_response" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[].number // empty' | sort -u)
+          # Extract issue numbers from GraphQL response, handling null closingIssuesReferences
+          issue_numbers=$(echo "$graphql_response" | jq -r '
+            if .data.repository.pullRequest.closingIssuesReferences then 
+              .data.repository.pullRequest.closingIssuesReferences.nodes[].number 
+            else 
+              empty 
+            end' | sort -u)
           
           if [ -z "$issue_numbers" ]; then
-            echo "No linked issues found that would be closed by GitHub's automatic linking"
-            exit 0
+            echo "No linked issues found via GraphQL. Trying fallback method..."
+            
+            # Fallback: Check PR description for closing keywords
+            pr_body="${{ github.event.pull_request.body }}"
+            echo "PR Body: $pr_body"
+            
+            # Extract issue numbers from PR body using common closing keywords
+            fallback_issues=$(echo "$pr_body" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+            
+            if [ -n "$fallback_issues" ]; then
+              echo "Found issues via fallback method: $fallback_issues"
+              issue_numbers="$fallback_issues"
+            else
+              echo "No linked issues found that would be closed by GitHub's automatic linking or PR body keywords"
+              exit 0
+            fi
           fi
           
           echo "Found GitHub-linked issues: $issue_numbers"
@@ -101,7 +133,7 @@ jobs:
                   -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
                   "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number/comments" \
-                  -d "{\"body\":\"This issue is being closed because the related PR #${{ github.event.pull_request.number }} has been merged into a release branch.\"}"
+                  -d "{\"body\":\"This issue is being closed because the related PR #${{ github.event.pull_request.number }} has been merged into a release branch (\`${{ github.event.pull_request.base.ref }}\`).\"}"
 
                 comment_http_code=$(awk 'NR==1 {print $2}' "$comment_headers")
 
@@ -109,12 +141,14 @@ jobs:
                   echo "✅ Added comment to issue #$issue_number"
                 else
                   echo "⚠️ Failed to add comment to issue #$issue_number (HTTP $comment_http_code)"
+                  echo "Comment response: $(cat "$comment_tmpfile")"
                 fi
                 
                 # Clean up comment temp files
                 rm -f "$comment_tmpfile" "$comment_headers"
               else
                 echo "❌ Failed to close issue #$issue_number (HTTP $close_http_code)"
+                echo "Close response: $(cat "$close_tmpfile")"
               fi
               
               # Clean up close temp files

--- a/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
+++ b/.github/workflows/close-issues-on-pr-merge-to-release-branch.yml
@@ -91,8 +91,8 @@ jobs:
             pr_body="${{ github.event.pull_request.body }}"
             echo "PR Body: $pr_body"
             
-            # Extract issue numbers from PR body using common closing keywords
-            fallback_issues=$(echo "$pr_body" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+            # Extract issue numbers from PR body using common closing keywords and multiple formats
+            fallback_issues=$(echo "$pr_body" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[: ]+((#[0-9]+([, ]+)?)+)' | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
             
             if [ -n "$fallback_issues" ]; then
               echo "Found issues via fallback method: $fallback_issues"


### PR DESCRIPTION
Adds debug output and a fallback method to extract issue numbers from PR body if GraphQL does not return linked issues. Also enhances logging for API responses and updates the branch check to use the PR base ref. These changes improve reliability and troubleshooting for the workflow that closes issues when a PR is merged into a release branch.

## Summary by Sourcery

Improve reliability and troubleshooting of the workflow that automatically closes issues when a pull request is merged into a release branch

CI:
- Use the PR base ref instead of the git ref for release branch filtering
- Add debug output for PR context and raw GraphQL API responses
- Implement fallback extraction of issue numbers from the PR body when GraphQL returns none
- Enhance logging of API responses and include the target branch in closing comments