### PR TITLE
feat(scan-engines): add new scan engine variants and enhance configuration options

### DIFF
--- a/web/config/default_scan_engines/Initial Scan - Passive with screenshots (common ports).yaml
+++ b/web/config/default_scan_engines/Initial Scan - Passive with screenshots (common ports).yaml
@@ -29,7 +29,15 @@ http_crawl: {
   #   'User-Agent': 'Mozilla/5.0'
   # },
   # 'threads': 30,
-  # 'follow_redirect': false
+  # 'follow_redirect': false,
+  # Precrawl configuration - controls which ports are tested during initial crawl
+  # 'precrawl_ports': [80, 443, 8080, 8081, 8082, 8443, 3000, 3001, 5000, 9000],  # Common ports (always tested)
+  # 'precrawl_uncommon_ports': false,  # Set to true to also test uncommon ports (81-55672)
+  # 'precrawl_all_ports': false,       # Set to true to test all ports (common + uncommon), overrides precrawl_uncommon_ports
+  # Batch size for processing URLs
+  # Smaller batches = more granular control, better error handling
+  # Larger batches = potentially faster but higher memory usage and risk of overwhelming the system
+  # 'precrawl_batch_size': 350
 }
 osint: {
   'discover': [
@@ -37,23 +45,6 @@ osint: {
       'metainfo',
       'employees'
     ],
-  'dorks': [
-    'login_pages',
-    'admin_panels',
-    'dashboard_pages',
-    'stackoverflow',
-    'social_media',
-    'project_management',
-    'code_sharing',
-    'config_files',
-    'jenkins',
-    'wordpress_files',
-    'php_error',
-    'exposed_documents',
-    'db_files',
-    'git_exposed'
-  ],
-  # 'custom_dorks': [],
   'intensity': 'normal',
   'documents_limit': 50
 }

--- a/web/config/default_scan_engines/Initial Scan - Passive with screenshots (common-uncommon ports).yaml
+++ b/web/config/default_scan_engines/Initial Scan - Passive with screenshots (common-uncommon ports).yaml
@@ -1,6 +1,6 @@
-# This scan engine is used to import subdomains from a given list and scan them passively
-# The fastest scan for retrieving a lot of informations on a given scope of urls
-# QUICK SCAN - USE LESS RESOURCES - NO SUBDOMAIN RECOVERY - RECOMMENDED ON INITIAL SCAN
+# This scan engine is used to discover subdomains and scan them passively with screenshots
+# The fastest scan for retrieving a lot of informations on the target
+# QUICK SCAN - USE LESS RESOURCES - HIGHLY RECOMMENDED ON INITIAL SCAN
 
 # Global vars for all tools
 #
@@ -9,12 +9,20 @@ custom_header: {
   'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0',
 }
 # 'user_agent': ''                    # Dalfox only
-# 'timeout': 10                       # Subdomain discovery, Screenshot, Port scan, FFUF, Nuclei
+# 'timeout': 10                       # Subdomain discovery, Screenshot, Port scan, FFUF, Nuclei                       
 # 'threads': 30                       # All tools
 # 'rate_limit': 150                   # Port scan, FFUF, Nuclei
 # 'intensity': 'normal'               # Screenshot (grab only the root endpoints of each subdomain), Nuclei (reduce number of endpoints to scan), OSINT (not implemented yet)
 # 'retries': 1                        # Nuclei
 
+subdomain_discovery: {
+  'uses_tools': ['subfinder', 'ctfr', 'sublist3r', 'tlsx', 'oneforall', 'netlas'],  # amass-passive, amass-active, All
+  'threads': 30,
+  'timeout': 5,
+  # 'use_subfinder_config': false,
+  # 'use_amass_config': false,
+  # 'amass_wordlist': 'deepmagic.com-prefixes-top50000'
+}
 http_crawl: {
   # 'custom_header': {
   #   'Cookie':'Test',

--- a/web/config/default_scan_engines/Initial Scan - reNgine recommended.yaml
+++ b/web/config/default_scan_engines/Initial Scan - reNgine recommended.yaml
@@ -29,7 +29,16 @@ http_crawl: {
   #   'User-Agent': 'Mozilla/5.0'
   # },
   'threads': 10,
-  # 'follow_redirect': false
+  # 'follow_redirect': false,
+  # Precrawl configuration - controls which ports are tested during initial crawl
+  # 'precrawl_ports': [80, 443, 8080, 8081, 8082, 8443, 3000, 3001, 5000, 9000],  # Common ports (always tested)
+  # 'precrawl_uncommon_ports': false,  # Set to true to also test uncommon ports (81-55672)
+  # 'precrawl_all_ports': false,       # Set to true to test all ports (common + uncommon), overrides precrawl_uncommon_ports
+  # Batch size for processing URLs
+  # Smaller batches = more granular control, better error handling
+  # Larger batches = potentially faster but higher memory usage and risk of overwhelming the system
+  # 'precrawl_batch_size': 350
+
 }
 osint: {
   'discover': [
@@ -37,23 +46,6 @@ osint: {
       'metainfo',
       'employees'
     ],
-#  'dorks': [
-#    'login_pages',
-#    'admin_panels',
-#    'dashboard_pages',
-#    'stackoverflow',
-#    'social_media',
-#    'project_management',
-#    'code_sharing',
-#    'config_files',
-#    'jenkins',
-#    'wordpress_files',
-#    'php_error',
-#    'exposed_documents',
-#    'db_files',
-#    'git_exposed'
-#  ],
-  # 'custom_dorks': [],
   'intensity': 'normal',
   'documents_limit': 50
 }

--- a/web/config/default_scan_engines/README.md
+++ b/web/config/default_scan_engines/README.md
@@ -32,12 +32,15 @@ python3 manage.py loaddefaultengines
 
 ## 📋 Available engines
 
-The following engines are available in this directory:
+The following engines are currently provided (engine name equals the filename without the `.yaml` extension):
 
 - **Initial Scan - reNgine recommended**: Recommended scan for initial analysis
-- **Initial Scan - Passive**: Fast passive scan
-- **Initial Scan - Passive with screenshots**: Passive scan with screenshots
-- **Scan - Active**: Complete active scan (resource intensive)
+- **Initial Scan - Passive (import subdomains)**: Fast passive scan importing subdomains
+- **Initial Scan - Passive with screenshots (common ports)**: Passive scan with screenshots on common ports
+- **Initial Scan - Passive with screenshots (common-uncommon ports)**: Passive scan with screenshots on common and uncommon ports
+- **Scan - Active (common ports)**: Active scan targeting common ports
+- **Scan - Active (common-uncommon ports)**: Active scan targeting common and uncommon ports
+- **Scan - Active (import subdomains - common ports)**: Active scan importing subdomains on common ports
 - **Subscan - Screenshots**: Screenshots only
 - **Subscan - Port scan**: Port scan only
 - **Subscan - Vulnerabilities**: Vulnerability scan only

--- a/web/config/default_scan_engines/Scan - Active (common ports).yaml
+++ b/web/config/default_scan_engines/Scan - Active (common ports).yaml
@@ -1,0 +1,112 @@
+# This scan engine is used to discover subdomains and scan them actively
+# The most complete scan for retrieving a lot of informations on the target
+# /!\ RESOURCE INTENSIVE SCAN - NOT RECOMMENDED ON INITIAL SCAN - USE ONLY IF YOU KNOW WHAT YOU ARE DOING
+
+# Global vars for all tools
+#
+# Custom header - FFUF, Nuclei, Dalfox, CRL Fuzz, HTTPx, Fetch URL (Hakrawler, Katana, Gospider)
+custom_header: {
+  'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0',
+}
+# 'user_agent': ''                    # Dalfox only
+# 'timeout': 10                       # Subdomain discovery, Screenshot, Port scan, FFUF, Nuclei                       
+# 'threads': 30                       # All tools
+# 'rate_limit': 150                   # Port scan, FFUF, Nuclei
+# 'intensity': 'normal'               # Screenshot (grab only the root endpoints of each subdomain), Nuclei (reduce number of endpoints to scan), OSINT (not implemented yet)
+# 'retries': 1                        # Nuclei
+
+subdomain_discovery: {
+  'uses_tools': ['subfinder', 'ctfr', 'sublist3r', 'tlsx', 'oneforall', 'netlas'],  # amass-passive, amass-active, All
+  'threads': 30,
+  'timeout': 5,
+  # 'use_subfinder_config': false,
+  # 'use_amass_config': false,
+  # 'amass_wordlist': 'deepmagic.com-prefixes-top50000'
+}
+
+http_crawl: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0'
+  # },
+  # 'threads': 30,
+  # 'follow_redirect': false,
+  # Precrawl configuration - controls which ports are tested during initial crawl
+  # 'precrawl_ports': [80, 443, 8080, 8081, 8082, 8443, 3000, 3001, 5000, 9000],  # Common ports (always tested)
+  # 'precrawl_uncommon_ports': false,  # Set to true to also test uncommon ports (81-55672)
+  # 'precrawl_all_ports': false,       # Set to true to test all ports (common + uncommon), overrides precrawl_uncommon_ports
+  # Batch size for processing URLs
+  # Smaller batches = more granular control, better error handling
+  # Larger batches = potentially faster but higher memory usage and risk of overwhelming the system
+  # 'precrawl_batch_size': 350
+}
+port_scan: {
+  'timeout': 5,
+  # 'exclude_ports': [],
+  # 'exclude_subdomains': [],
+  'ports': ['top-100'],
+  'rate_limit': 150,
+  'threads': 30,
+  'passive': false,
+  # 'use_naabu_config': false,
+  # 'enable_nmap': true,
+  # 'nmap_cmd': '',
+  # 'nmap_script': '',
+  # 'nmap_script_args': ''
+}
+dir_file_fuzz: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0',
+  #   'Custom-Header': 'My custom header'
+  # },
+  'auto_calibration': true,
+  'rate_limit': 150,
+  'extensions': [],
+  'follow_redirect': false,
+  'max_time': 0,
+  'match_http_status': [200, 204, 403, 500],
+  'recursive_level': 0,
+  'stop_on_error': false,
+  'timeout': 5,
+  'threads': 10,
+  'wordlist_name': 'default', # fuzz-Bo0oM
+}
+fetch_url: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0',
+  #   'Custom-Header': 'My custom header'
+  # },
+  'uses_tools': ['gospider', 'hakrawler', 'waybackurls', 'katana', 'gau'],
+  'remove_duplicate_endpoints': true,
+  'duplicate_fields': ['content_length', 'page_title'],
+  'gf_patterns': ['debug_logic', 'idor', 'interestingEXT', 'interestingparams', 'interestingsubs', 'lfi', 'rce', 'redirect', 'sqli', 'ssrf', 'ssti', 'xss'],
+  'ignore_file_extensions': ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'mpeg', 'mp3'],
+  'threads': 10,
+  # 'exclude_subdomains': false
+}
+vulnerability_scan: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0',
+  #   'Custom-Header': 'My custom header'
+  # },
+  'run_nuclei': true,
+  'run_dalfox': false,
+  'run_crlfuzz': false,
+  'run_s3scanner': false,
+  'concurrency': 50,
+  'intensity': 'normal',
+  'rate_limit': 25,
+  'retries': 1,
+  'timeout': 5,
+  'fetch_llm_report': false,
+  'nuclei': {
+    'use_nuclei_config': false,
+    'severities': ['unknown', 'info', 'low', 'medium', 'high', 'critical'],
+    # 'tags': [],                 # Nuclei tags (https://github.com/projectdiscovery/nuclei-templates)
+    # 'templates': [],            # Nuclei templates (https://github.com/projectdiscovery/nuclei-templates)
+    # 'custom_templates': []      # Nuclei custom templates uploaded in reNgine
+  }
+}

--- a/web/config/default_scan_engines/Scan - Active (common-uncommon ports).yaml
+++ b/web/config/default_scan_engines/Scan - Active (common-uncommon ports).yaml
@@ -1,6 +1,7 @@
 # This scan engine is used to discover subdomains and scan them actively
 # The most complete scan for retrieving a lot of informations on the target
 # /!\ RESOURCE INTENSIVE SCAN - NOT RECOMMENDED ON INITIAL SCAN - USE ONLY IF YOU KNOW WHAT YOU ARE DOING
+# This scan engine is used to discover subdomains and scan them actively with uncommon ports (VERY LONG ON HUGE SCOPES)
 
 # Global vars for all tools
 #
@@ -15,13 +16,30 @@ custom_header: {
 # 'intensity': 'normal'               # Screenshot (grab only the root endpoints of each subdomain), Nuclei (reduce number of endpoints to scan), OSINT (not implemented yet)
 # 'retries': 1                        # Nuclei
 
+subdomain_discovery: {
+  'uses_tools': ['subfinder', 'ctfr', 'sublist3r', 'tlsx', 'oneforall', 'netlas'],  # amass-passive, amass-active, All
+  'threads': 30,
+  'timeout': 5,
+  # 'use_subfinder_config': false,
+  # 'use_amass_config': false,
+  # 'amass_wordlist': 'deepmagic.com-prefixes-top50000'
+}
+
 http_crawl: {
   # 'custom_header': {
   #   'Cookie':'Test',
   #   'User-Agent': 'Mozilla/5.0'
   # },
   # 'threads': 30,
-  # 'follow_redirect': false
+  # 'follow_redirect': false,
+  # Precrawl configuration - controls which ports are tested during initial crawl
+  # 'precrawl_ports': [80, 443, 8080, 8081, 8082, 8443, 3000, 3001, 5000, 9000],  # Common ports (always tested)
+  # 'precrawl_uncommon_ports': false,  # Set to true to also test uncommon ports (81-55672)
+  'precrawl_all_ports': true,       # Set to true to test all ports (common + uncommon), overrides precrawl_uncommon_ports
+  # Batch size for processing URLs
+  # Smaller batches = more granular control, better error handling
+  # Larger batches = potentially faster but higher memory usage and risk of overwhelming the system
+  # 'precrawl_batch_size': 350
 }
 port_scan: {
   'timeout': 5,

--- a/web/config/default_scan_engines/Scan - Active (import subdomains - common ports).yaml
+++ b/web/config/default_scan_engines/Scan - Active (import subdomains - common ports).yaml
@@ -1,0 +1,103 @@
+# This scan engine is used to discover subdomains and scan them actively
+# The most complete scan for retrieving a lot of informations on the target
+# /!\ RESOURCE INTENSIVE SCAN - NOT RECOMMENDED ON INITIAL SCAN - USE ONLY IF YOU KNOW WHAT YOU ARE DOING
+
+# Global vars for all tools
+#
+# Custom header - FFUF, Nuclei, Dalfox, CRL Fuzz, HTTPx, Fetch URL (Hakrawler, Katana, Gospider)
+custom_header: {
+  'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0',
+}
+# 'user_agent': ''                    # Dalfox only
+# 'timeout': 10                       # Subdomain discovery, Screenshot, Port scan, FFUF, Nuclei                       
+# 'threads': 30                       # All tools
+# 'rate_limit': 150                   # Port scan, FFUF, Nuclei
+# 'intensity': 'normal'               # Screenshot (grab only the root endpoints of each subdomain), Nuclei (reduce number of endpoints to scan), OSINT (not implemented yet)
+# 'retries': 1                        # Nuclei
+
+http_crawl: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0'
+  # },
+  # 'threads': 30,
+  # 'follow_redirect': false,
+  # Precrawl configuration - controls which ports are tested during initial crawl
+  # 'precrawl_ports': [80, 443, 8080, 8081, 8082, 8443, 3000, 3001, 5000, 9000],  # Common ports (always tested)
+  # 'precrawl_uncommon_ports': false,  # Set to true to also test uncommon ports (81-55672)
+  # 'precrawl_all_ports': false,       # Set to true to test all ports (common + uncommon), overrides precrawl_uncommon_ports
+  # Batch size for processing URLs
+  # Smaller batches = more granular control, better error handling
+  # Larger batches = potentially faster but higher memory usage and risk of overwhelming the system
+  # 'precrawl_batch_size': 350
+}
+port_scan: {
+  'timeout': 5,
+  # 'exclude_ports': [],
+  # 'exclude_subdomains': [],
+  'ports': ['top-100'],
+  'rate_limit': 150,
+  'threads': 30,
+  'passive': false,
+  # 'use_naabu_config': false,
+  # 'enable_nmap': true,
+  # 'nmap_cmd': '',
+  # 'nmap_script': '',
+  # 'nmap_script_args': ''
+}
+dir_file_fuzz: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0',
+  #   'Custom-Header': 'My custom header'
+  # },
+  'auto_calibration': true,
+  'rate_limit': 150,
+  'extensions': [],
+  'follow_redirect': false,
+  'max_time': 0,
+  'match_http_status': [200, 204, 403, 500],
+  'recursive_level': 0,
+  'stop_on_error': false,
+  'timeout': 5,
+  'threads': 10,
+  'wordlist_name': 'default', # fuzz-Bo0oM
+}
+fetch_url: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0',
+  #   'Custom-Header': 'My custom header'
+  # },
+  'uses_tools': ['gospider', 'hakrawler', 'waybackurls', 'katana', 'gau'],
+  'remove_duplicate_endpoints': true,
+  'duplicate_fields': ['content_length', 'page_title'],
+  'gf_patterns': ['debug_logic', 'idor', 'interestingEXT', 'interestingparams', 'interestingsubs', 'lfi', 'rce', 'redirect', 'sqli', 'ssrf', 'ssti', 'xss'],
+  'ignore_file_extensions': ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'mpeg', 'mp3'],
+  'threads': 10,
+  # 'exclude_subdomains': false
+}
+vulnerability_scan: {
+  # 'custom_header': {
+  #   'Cookie':'Test',
+  #   'User-Agent': 'Mozilla/5.0',
+  #   'Custom-Header': 'My custom header'
+  # },
+  'run_nuclei': true,
+  'run_dalfox': false,
+  'run_crlfuzz': false,
+  'run_s3scanner': false,
+  'concurrency': 50,
+  'intensity': 'normal',
+  'rate_limit': 25,
+  'retries': 1,
+  'timeout': 5,
+  'fetch_llm_report': false,
+  'nuclei': {
+    'use_nuclei_config': false,
+    'severities': ['unknown', 'info', 'low', 'medium', 'high', 'critical'],
+    # 'tags': [],                 # Nuclei tags (https://github.com/projectdiscovery/nuclei-templates)
+    # 'templates': [],            # Nuclei templates (https://github.com/projectdiscovery/nuclei-templates)
+    # 'custom_templates': []      # Nuclei custom templates uploaded in reNgine
+  }
+}


### PR DESCRIPTION
Fix #299 

## Summary by Sourcery

Introduce new active and passive scan engine variants with enhanced port-targeting options, refine existing configurations with additional precrawl settings, and update documentation to reflect the expanded engine lineup

New Features:
- Add passive scan variants importing subdomains and capturing screenshots on common and uncommon ports
- Add active scan variants targeting common ports, targeting both common and uncommon ports, and importing subdomains on common ports

Enhancements:
- Extend existing scan engine YAMLs with optional precrawl configuration parameters for port selection and batch sizing
- Remove or comment out unused OSINT dork lists and redundant settings in default scan engine files

Documentation:
- Update README to list and describe the new scan engine variants

## Summary by Sourcery

Add new passive and active scan engine configurations and enhance existing scan engine YAMLs with advanced precrawl settings

New Features:
- Add passive scan variants importing subdomains
- Add passive scan variants capturing screenshots on common and uncommon ports
- Add active scan variants targeting common ports
- Add active scan variants targeting common and uncommon ports
- Add active scan variants importing subdomains on common ports

Enhancements:
- Extend existing scan engine YAMLs with optional precrawl port selection and batch size parameters
- Remove or comment out unused OSINT dork lists and redundant settings in default scan engine files

Documentation:
- Update README to list and describe the expanded set of scan engine variants