### PR TITLE
fix(ci): update Docker image tagging logic in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,7 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ !contains(github.ref, 'release/') }}
             type=ref,event=pr
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=v${{ steps.get_version.outputs.version }},enable=${{ contains(github.ref, 'release/') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=v${{ steps.get_version.outputs.version }},enable=${{ contains(github.ref, 'release/') || github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
           flavor: |
             prefix=rengine-${{ matrix.image }}-,onlatest=true


### PR DESCRIPTION
fix #313 

- Refines the conditions for applying Docker image tags in the GitHub Actions build workflow, consolidating and simplifying tag assignment for release and tag events.