### PR TITLE
fix(ui): update get_technologies to accept subdomain endpoint and update usage

### DIFF
--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -2067,7 +2067,7 @@ $(document).ready(function() {
 	get_recon_notes('{% url 'api:listTodoNotes' %}', target_id=null, scan_history_id={{scan_history_id}});
 
 	get_ips('{{ ip_addresses|safe }}', '{% url 'api:getIpDetails' %}', '{% url 'api:querySubdomains' %}', scan_id={{scan_history_id}}, domain_id=null);
-	get_technologies('{% url 'api:listTechnologies' %}', scan_id={{scan_history_id}}, domain_id=null);
+	get_technologies('{% url 'api:listTechnologies' %}', '{% url 'api:querySubdomains' %}', scan_id={{scan_history_id}}, domain_id=null);
 	get_ports('{{ ip_addresses|safe }}', '{% url 'api:listIPs' %}', '{% url 'api:querySubdomains' %}', scan_id={{scan_history_id}}, domain_id=null);
 
 	get_subdomain_changes('{% url 'api:subdomain-changes-list' %}', {{scan_history_id}});

--- a/web/static/custom/custom.js
+++ b/web/static/custom/custom.js
@@ -2157,7 +2157,7 @@ function loadSubscanHistoryWidget(endpoint, scan_history_id = null, domain_id = 
 	});
 }
 
-function get_technologies(endpoint_url, scan_id=null, domain_id=null){
+function get_technologies(endpoint_url, subdomain_endpoint_url, scan_id=null, domain_id=null){
 	// this function will fetch and render tech in widget
 	var url = `${endpoint_url}?`;
 
@@ -2176,10 +2176,10 @@ function get_technologies(endpoint_url, scan_id=null, domain_id=null){
 		for (var val in data['technologies']){
 			tech = data['technologies'][val]
 			if (scan_id) {
-				$("#technologies").append(`<span class='badge badge-soft-primary  m-1 badge-link' data-toggle="tooltip" title="${tech['count']} Subdomains use this technology." onclick="get_tech_details('${endpoint_url}', '${tech['name']}', scan_id=${scan_id}, domain_id=null)">${tech['name']}</span>`);
+				$("#technologies").append(`<span class='badge badge-soft-primary  m-1 badge-link' data-toggle="tooltip" title="${tech['count']} Subdomains use this technology." onclick="get_tech_details('${subdomain_endpoint_url}', '${tech['name']}', scan_id=${scan_id}, domain_id=null)">${tech['name']}</span>`);
 			}
 			else if (domain_id) {
-				$("#technologies").append(`<span class='badge badge-soft-primary  m-1 badge-link' data-toggle="tooltip" title="${tech['count']} Subdomains use this technology." onclick="get_tech_details('${endpoint_url}', '${tech['name']}', scan_id=null, domain_id=${domain_id})">${tech['name']}</span>`);
+				$("#technologies").append(`<span class='badge badge-soft-primary  m-1 badge-link' data-toggle="tooltip" title="${tech['count']} Subdomains use this technology." onclick="get_tech_details('${subdomain_endpoint_url}', '${tech['name']}', scan_id=null, domain_id=${domain_id})">${tech['name']}</span>`);
 			}
 		}
 		$('#technologies-count').html(`<span class="badge badge-soft-primary me-1">${data['technologies'].length}</span>`);

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -1657,7 +1657,7 @@ $(document).ready(function(){
 	get_recon_notes('{% url 'api:listTodoNotes' %}', target_id={{target.id}}, scan_history_id=null);
 
 	get_ips('{{ ip_addresses|safe }}', '{% url 'api:getIpDetails' %}', '{% url 'api:querySubdomains' %}', scan_id=null, domain_id={{target.id}});
-	get_technologies('{% url 'api:listTechnologies' %}', scan_id=null, domain_id={{target.id}});
+	get_technologies('{% url 'api:listTechnologies' %}', '{% url 'api:querySubdomains' %}', scan_id=null, domain_id={{target.id}});
 	get_ports('{{ ip_addresses }}', '{% url 'api:listIPs' %}', '{% url 'api:querySubdomains' %}', scan_id=null, domain_id={{target.id}});
 
 	var clipboard = new Clipboard('.copyable');


### PR DESCRIPTION
Fix #323 

- Modified the get_technologies function to accept an additional subdomain endpoint URL parameter.
- Updated all usages of get_technologies in HTML templates to provide the new subdomain endpoint argument.
- Ensured technology detail links use the subdomain endpoint for fetching technology details.
- Fix screenshot display

<img width="789" height="1033" alt="image" src="https://github.com/user-attachments/assets/bcf40d36-ed61-488d-a040-812e70a80b9c" />
