### PR TITLE
fix(celery): add isolated task context for thread safety and context management

### DIFF
--- a/web/reNgine/celery_custom_task.py
+++ b/web/reNgine/celery_custom_task.py
@@ -370,6 +370,7 @@ class RengineTask(Task):
 					logger.warning(f'Task {task_identifier} is RUNNING')
 				self.create_scan_activity()
 
+		record_key = None
 		if RENGINE_CACHE_ENABLED:
 			# Check for result in cache and return it if it's a hit
 			record_key = get_task_cache_key(self.name, *args, **kwargs)
@@ -431,7 +432,7 @@ class RengineTask(Task):
 				self.update_scan_activity()
 
 		# Set task result in cache if task was successful
-		if RENGINE_CACHE_ENABLED and context.status == SUCCESS_TASK and context.result:
+		if RENGINE_CACHE_ENABLED and record_key is not None and context.status == SUCCESS_TASK and context.result:
 			cache.set(record_key, json.dumps(context.result))
 			cache.expire(record_key, 600) # 10mn cache
 

--- a/web/reNgine/celery_custom_task.py
+++ b/web/reNgine/celery_custom_task.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 
 from celery import Task
 from celery.utils.log import get_task_logger
@@ -31,6 +32,70 @@ if 'CELERY_BROKER' in os.environ:
 	cache = Redis.from_url(os.environ['CELERY_BROKER'])
 
 
+class TaskContext:
+	"""Isolated context class to prevent context pollution between concurrent tasks"""
+	
+	def __init__(self, ctx=None, request=None, task_name=None, description=None):
+		"""Initialize task context with isolated variables"""
+		if ctx is None:
+			ctx = {}
+			
+		# Core task info
+		self.task_name = task_name
+		self.description = description
+		self.request = request
+		
+		# Execution state
+		self.result = None
+		self.error = None
+		self.traceback = None
+		self.output_path = None
+		self.status = RUNNING_TASK
+		
+		# Context variables from ctx parameter
+		self.track = ctx.get('track', True)
+		self.scan_id = ctx.get('scan_history_id')
+		self.subscan_id = ctx.get('subscan_id') 
+		self.engine_id = ctx.get('engine_id')
+		self.filename = ctx.get('filename')
+		self.url_filter = ctx.get('url_filter', '')
+		self.results_dir = ctx.get('results_dir', RENGINE_RESULTS)
+		self.yaml_configuration = ctx.get('yaml_configuration', {})
+		self.out_of_scope_subdomains = ctx.get('out_of_scope_subdomains', [])
+		
+		# Derived paths
+		self.history_file = f'{self.results_dir}/commands.txt'
+		
+		# Database objects - initialized separately for thread safety
+		self.scan = None
+		self.subscan = None
+		self.engine = None
+		self.domain = None
+		self.domain_id = None
+		self.subdomain = None
+		self.subdomain_id = None
+		self.activity_id = None
+		self.activity = None
+		
+	def load_database_objects(self):
+		"""Load database objects in a thread-safe manner"""
+		from startScan.models import ScanHistory, SubScan
+		from scanEngine.models import EngineType
+		
+		self.scan = ScanHistory.objects.filter(pk=self.scan_id).first()
+		self.subscan = SubScan.objects.filter(pk=self.subscan_id).first()
+		self.engine = EngineType.objects.filter(pk=self.engine_id).first()
+		self.domain = self.scan.domain if self.scan else None
+		self.domain_id = self.domain.id if self.domain else None
+		self.subdomain = self.subscan.subdomain if self.subscan else None
+		self.subdomain_id = self.subdomain.id if self.subdomain else None
+		
+	@property
+	def status_str(self):
+		"""Get string representation of task status"""
+		return CELERY_TASK_STATUS_MAP.get(self.status)
+
+
 class RengineRequest(Request):
 	success_msg = ''
 	retry_msg = ''
@@ -55,56 +120,210 @@ class RengineTask(Task):
 	- Raise the actual exception when task fails instead of just logging it.
 	"""
 	Request = RengineRequest
+	
+	def __init__(self):
+		super().__init__()
+		# Thread-local storage for context isolation
+		self._local = threading.local()
 
 	@property
+	def context(self):
+		"""Get the current task context for this thread"""
+		if not hasattr(self._local, 'context'):
+			return None
+		return self._local.context
+		
+	@property 
 	def status_str(self):
-		return CELERY_TASK_STATUS_MAP.get(self.status)
+		"""Get status string from context if available, fallback to instance"""
+		if self.context:
+			return self.context.status_str
+		return CELERY_TASK_STATUS_MAP.get(getattr(self, 'status', None))
+		
+	# Proxy properties to context for backward compatibility
+	@property
+	def result(self):
+		return self.context.result if self.context else getattr(self, '_result', None)
+	
+	@result.setter 
+	def result(self, value):
+		if self.context:
+			self.context.result = value
+		else:
+			self._result = value
+			
+	@property
+	def scan_id(self):
+		return self.context.scan_id if self.context else getattr(self, '_scan_id', None)
+		
+	@property
+	def domain(self):
+		return self.context.domain if self.context else getattr(self, '_domain', None)
+		
+	@property
+	def domain_id(self):
+		return self.context.domain_id if self.context else getattr(self, '_domain_id', None)
+		
+	@property
+	def subdomain(self):
+		return self.context.subdomain if self.context else getattr(self, '_subdomain', None)
+		
+	@property
+	def activity_id(self):
+		return self.context.activity_id if self.context else getattr(self, '_activity_id', None)
+		
+	@activity_id.setter
+	def activity_id(self, value):
+		if self.context:
+			self.context.activity_id = value
+		else:
+			self._activity_id = value
+		
+	@property
+	def results_dir(self):
+		return self.context.results_dir if self.context else getattr(self, '_results_dir', None)
+		
+	@property
+	def output_path(self):
+		return self.context.output_path if self.context else getattr(self, '_output_path', None)
+		
+	@output_path.setter
+	def output_path(self, value):
+		if self.context:
+			self.context.output_path = value
+		else:
+			self._output_path = value
+		
+	@property
+	def yaml_configuration(self):
+		return self.context.yaml_configuration if self.context else getattr(self, '_yaml_configuration', {})
+		
+	@property
+	def url_filter(self):
+		return self.context.url_filter if self.context else getattr(self, '_url_filter', '')
+		
+	@property
+	def out_of_scope_subdomains(self):
+		return self.context.out_of_scope_subdomains if self.context else getattr(self, '_out_of_scope_subdomains', [])
+		
+	@property
+	def history_file(self):
+		return self.context.history_file if self.context else getattr(self, '_history_file', None)
+		
+	@property
+	def scan(self):
+		return self.context.scan if self.context else getattr(self, '_scan', None)
+		
+	@property
+	def subscan(self):
+		return self.context.subscan if self.context else getattr(self, '_subscan', None)
+		
+	@property
+	def engine(self):
+		return self.context.engine if self.context else getattr(self, '_engine', None)
+		
+	@property
+	def subscan_id(self):
+		return self.context.subscan_id if self.context else getattr(self, '_subscan_id', None)
+		
+	@property
+	def engine_id(self):
+		return self.context.engine_id if self.context else getattr(self, '_engine_id', None)
+		
+	@property
+	def track(self):
+		return self.context.track if self.context else getattr(self, '_track', True)
+		
+	@property
+	def task_name(self):
+		return self.context.task_name if self.context else getattr(self, '_task_name', None)
+		
+	@property
+	def description(self):
+		return self.context.description if self.context else getattr(self, '_description', None)
+		
+	@property
+	def filename(self):
+		return self.context.filename if self.context else getattr(self, '_filename', None)
+		
+	@filename.setter
+	def filename(self, value):
+		if self.context:
+			self.context.filename = value
+		else:
+			self._filename = value
+		
+	@property
+	def status(self):
+		return self.context.status if self.context else getattr(self, '_status', None)
+		
+	@status.setter
+	def status(self, value):
+		if self.context:
+			self.context.status = value
+		else:
+			self._status = value
+		
+	@property
+	def error(self):
+		return self.context.error if self.context else getattr(self, '_error', None)
+		
+	@error.setter
+	def error(self, value):
+		if self.context:
+			self.context.error = value
+		else:
+			self._error = value
+		
+	@property
+	def traceback(self):
+		return self.context.traceback if self.context else getattr(self, '_traceback', None)
+		
+	@traceback.setter
+	def traceback(self, value):
+		if self.context:
+			self.context.traceback = value
+		else:
+			self._traceback = value
+		
+	@property
+	def subdomain_id(self):
+		return self.context.subdomain_id if self.context else getattr(self, '_subdomain_id', None)
 
 	def __call__(self, *args, **kwargs):
-		self.result = None
-		self.error = None
-		self.traceback = None
-		self.output_path = None
-		self.status = RUNNING_TASK
-
-		# Get task info
-		self.task_name = self.name.split('.')[-1]
-		self.description = kwargs.get('description') or ' '.join(self.task_name.split('_')).capitalize()
-		logger = get_task_logger(self.task_name)
-
-		# Get reNgine context
+		# Create isolated context for this task execution
+		task_name = self.name.split('.')[-1]
+		description = kwargs.get('description') or ' '.join(task_name.split('_')).capitalize()
 		ctx = kwargs.get('ctx', {})
-		self.track = ctx.get('track', True)
-		self.scan_id = ctx.get('scan_history_id')
-		self.subscan_id = ctx.get('subscan_id')
-		self.engine_id = ctx.get('engine_id')
-		self.filename = ctx.get('filename')
-		self.url_filter = ctx.get('url_filter', '')
-		self.results_dir = ctx.get('results_dir', RENGINE_RESULTS)
-		self.yaml_configuration = ctx.get('yaml_configuration', {})
-		self.out_of_scope_subdomains = ctx.get('out_of_scope_subdomains', [])
-		self.history_file = f'{self.results_dir}/commands.txt'
-		self.scan = ScanHistory.objects.filter(pk=self.scan_id).first()
-		self.subscan = SubScan.objects.filter(pk=self.subscan_id).first()
-		self.engine = EngineType.objects.filter(pk=self.engine_id).first()
-		self.domain = self.scan.domain if self.scan else None
-		self.domain_id = self.domain.id if self.domain else None
-		self.subdomain = self.subscan.subdomain if self.subscan else None
-		self.subdomain_id = self.subdomain.id if self.subdomain else None
-		self.activity_id = None
+		
+		# Create new context instance for this thread/execution
+		context = TaskContext(
+			ctx=ctx,
+			request=self.request,
+			task_name=task_name,
+			description=description
+		)
+		
+		# Store context in thread-local storage to prevent pollution
+		self._local.context = context
+		
+		# Load database objects
+		context.load_database_objects()
+		
+		logger = get_task_logger(context.task_name)
 
-		# Set file self.task_name if not already set
-		if not self.filename:
-			self.filename = get_output_file_name(
-				self.scan_id,
-				self.subscan_id,
-				f'{self.task_name}.txt')
-			if self.task_name == 'screenshot':
-				self.filename = 'Requests.csv'
-		self.output_path = f'{self.results_dir}/{self.filename}'
+		# Set filename if not already set
+		if not context.filename:
+			context.filename = get_output_file_name(
+				context.scan_id,
+				context.subscan_id,
+				f'{context.task_name}.txt')
+			if context.task_name == 'screenshot':
+				context.filename = 'Requests.csv'
+		context.output_path = f'{context.results_dir}/{context.filename}'
 
 		if RENGINE_RECORD_ENABLED:
-			if self.engine:
+			if context.engine:
 					# task not in engine.tasks, skip it.
 					# create a rule for tasks that has to run parallel like dalfox
 					# xss scan but not necessarily part of main task rather part like
@@ -130,23 +349,23 @@ class RengineTask(Task):
 
 					# Skip if task is not part of engine and not exempted
 					if (
-							self.track and
-							self.task_name not in self.engine.tasks and
-							dependent_tasks.get(self.task_name) not in self.engine.tasks and
-							self.task_name.lower() not in exempted_tasks
+							context.track and
+							context.task_name not in context.engine.tasks and
+							dependent_tasks.get(context.task_name) not in context.engine.tasks and
+							context.task_name.lower() not in exempted_tasks
 					):
-							logger.debug(f'Task {self.task_name} is not part of engine "{self.engine.engine_name}" tasks. Skipping.')
+							logger.debug(f'Task {context.task_name} is not part of engine "{context.engine.engine_name}" tasks. Skipping.')
 							return False
 
 			# Create ScanActivity for this task and send start scan notifs
-			if self.track:
+			if context.track:
 				# Build task identifier with description for better clarity
-				task_identifier = f'{self.task_name}'
-				if self.description and self.description != self.task_name.replace('_', ' ').capitalize():
-					task_identifier += f' ({self.description})'
+				task_identifier = f'{context.task_name}'
+				if context.description and context.description != context.task_name.replace('_', ' ').capitalize():
+					task_identifier += f' ({context.description})'
 				
-				if self.domain:
-					logger.warning(f'Task {task_identifier} for {self.subdomain.name if self.subdomain else self.domain.name} is RUNNING')
+				if context.domain:
+					logger.warning(f'Task {task_identifier} for {context.subdomain.name if context.subdomain else context.domain.name} is RUNNING')
 				else:
 					logger.warning(f'Task {task_identifier} is RUNNING')
 				self.create_scan_activity()
@@ -154,39 +373,39 @@ class RengineTask(Task):
 		if RENGINE_CACHE_ENABLED:
 			# Check for result in cache and return it if it's a hit
 			record_key = get_task_cache_key(self.name, *args, **kwargs)
-			result = cache.get(record_key)
-			if result and result != b'null':
-				self.status = SUCCESS_TASK
-				if RENGINE_RECORD_ENABLED and self.track:
+			cached_result = cache.get(record_key)
+			if cached_result and cached_result != b'null':
+				context.status = SUCCESS_TASK
+				if RENGINE_RECORD_ENABLED and context.track:
 					# Build task identifier with description for better clarity
-					task_identifier = f'{self.task_name}'
-					if self.description and self.description != self.task_name.replace('_', ' ').capitalize():
-						task_identifier += f' ({self.description})'
+					task_identifier = f'{context.task_name}'
+					if context.description and context.description != context.task_name.replace('_', ' ').capitalize():
+						task_identifier += f' ({context.description})'
 					
-					if self.domain:
-						logger.warning(f'Task {task_identifier} for {self.subdomain.name if self.subdomain else self.domain.name} status is SUCCESS (CACHED)')
+					if context.domain:
+						logger.warning(f'Task {task_identifier} for {context.subdomain.name if context.subdomain else context.domain.name} status is SUCCESS (CACHED)')
 					else:
 						logger.warning(f'Task {task_identifier} status is SUCCESS (CACHED)')
 					self.update_scan_activity()
-				return json.loads(result)
+				return json.loads(cached_result)
 
 		# Execute task, catch exceptions and update ScanActivity object after
 		# task has finished running.
 		try:
-			self.result = self.run(*args, **kwargs)
-			self.status = SUCCESS_TASK
+			context.result = self.run(*args, **kwargs)
+			context.status = SUCCESS_TASK
 
 		except Exception as exc:
-			self.status = FAILED_TASK
-			self.error = repr(exc)
-			self.traceback = fmt_traceback(exc)
-			self.result = self.traceback
-			self.output_path = get_traceback_path(
-				self.task_name,
-				self.results_dir,
-				self.scan_id,
-				self.subscan_id)
-			os.makedirs(os.path.dirname(self.output_path), exist_ok=True)
+			context.status = FAILED_TASK
+			context.error = repr(exc)
+			context.traceback = fmt_traceback(exc)
+			context.result = context.traceback
+			context.output_path = get_traceback_path(
+				context.task_name,
+				context.results_dir,
+				context.scan_id,
+				context.subscan_id)
+			os.makedirs(os.path.dirname(context.output_path), exist_ok=True)
 
 			if RENGINE_RAISE_ON_ERROR:
 				raise exc
@@ -196,122 +415,130 @@ class RengineTask(Task):
 		finally:
 			self.write_results()
 
-			if RENGINE_RECORD_ENABLED and self.track:
+			if RENGINE_RECORD_ENABLED and context.track:
 				# Build task identifier with description for better clarity
-				task_identifier = f'{self.task_name}'
-				if self.description and self.description != self.task_name.replace('_', ' ').capitalize():
-					task_identifier += f' ({self.description})'
+				task_identifier = f'{context.task_name}'
+				if context.description and context.description != context.task_name.replace('_', ' ').capitalize():
+					task_identifier += f' ({context.description})'
 				
-				if self.domain:
-					msg = f'Task {task_identifier} for {self.subdomain.name if self.subdomain else self.domain.name} status is {self.status_str}'
+				if context.domain:
+					msg = f'Task {task_identifier} for {context.subdomain.name if context.subdomain else context.domain.name} status is {context.status_str}'
 				else:
-					msg = f'Task {task_identifier} status is {self.status_str}'
-				msg += f' | Error: {self.error}' if self.error else ''
+					msg = f'Task {task_identifier} status is {context.status_str}'
+				msg += f' | Error: {context.error}' if context.error else ''
 				logger.warning(msg)
 				
 				self.update_scan_activity()
 
 		# Set task result in cache if task was successful
-		if RENGINE_CACHE_ENABLED and self.status == SUCCESS_TASK and result:
-			cache.set(record_key, json.dumps(result))
+		if RENGINE_CACHE_ENABLED and context.status == SUCCESS_TASK and context.result:
+			cache.set(record_key, json.dumps(context.result))
 			cache.expire(record_key, 600) # 10mn cache
 
-		return self.result
+		return context.result
 
 	def write_results(self):
-		if not self.result:
+		context = self.context
+		if not context or not context.result:
 			return False
-		is_json_results = isinstance(self.result, dict) or isinstance(self.result, list)
-		if not self.output_path:
+		is_json_results = isinstance(context.result, dict) or isinstance(context.result, list)
+		if not context.output_path:
 			return False
-		if not os.path.exists(self.output_path):
-			with open(self.output_path, 'w') as f:
+		if not os.path.exists(context.output_path):
+			with open(context.output_path, 'w') as f:
 				if is_json_results:
-					json.dump(self.result, f, indent=4)
+					json.dump(context.result, f, indent=4)
 				else:
-					f.write(self.result)
-			logger.warning(f'Wrote {self.task_name} results to {self.output_path}')
+					f.write(context.result)
+			logger.warning(f'Wrote {context.task_name} results to {context.output_path}')
 
 	def create_scan_activity(self):
-		# Build task identifier with description for better clarity
-		task_identifier = f'{self.task_name}'
-		if self.description and self.description != self.task_name.replace('_', ' ').capitalize():
-			task_identifier += f' ({self.description})'
-		
-		if not self.track:
+		context = self.context
+		if not context or not context.track:
 			return
-		celery_id = self.request.id
+			
+		# Build task identifier with description for better clarity
+		task_identifier = f'{context.task_name}'
+		if context.description and context.description != context.task_name.replace('_', ' ').capitalize():
+			task_identifier += f' ({context.description})'
 		
-		self.activity = ScanActivity(
-			name=self.task_name,
-			title=self.description,
+		celery_id = context.request.id
+		
+		context.activity = ScanActivity(
+			name=context.task_name,
+			title=context.description,
 			time=timezone.now(),
 			status=RUNNING_TASK,
 			celery_id=celery_id)
-		self.activity.save()
-		self.activity_id = self.activity.id
+		context.activity.save()
+		context.activity_id = context.activity.id
 		
-		if self.scan:
-			self.activity.scan_of = self.scan
-			self.activity.save()
-			self.scan.celery_ids.append(celery_id)
-			self.scan.save()
-		if self.subscan:
-			self.subscan.celery_ids.append(celery_id)
-			self.subscan.save()
+		if context.scan:
+			context.activity.scan_of = context.scan
+			context.activity.save()
+			context.scan.celery_ids.append(celery_id)
+			context.scan.save()
+		if context.subscan:
+			context.subscan.celery_ids.append(celery_id)
+			context.subscan.save()
 
 		# Send notification
 		self.notify()
 
 	def update_scan_activity(self):
-		# Build task identifier with description for better clarity
-		task_identifier = f'{self.task_name}'
-		if self.description and self.description != self.task_name.replace('_', ' ').capitalize():
-			task_identifier += f' ({self.description})'
-		
-		if not self.track:
+		context = self.context
+		if not context or not context.track:
 			return
+			
+		# Build task identifier with description for better clarity
+		task_identifier = f'{context.task_name}'
+		if context.description and context.description != context.task_name.replace('_', ' ').capitalize():
+			task_identifier += f' ({context.description})'
 
 		# Trim error before saving to DB
-		error_message = self.error
-		if self.error and len(self.error) > 300:
-			error_message = self.error[:288] + '...[trimmed]'
+		error_message = context.error
+		if context.error and len(context.error) > 300:
+			error_message = context.error[:288] + '...[trimmed]'
 
-		# Use celery_id to find the correct activity (more reliable than self.activity reference)
-		celery_id = getattr(self.request, 'id', 'NO_ID')
+		# Use celery_id to find the correct activity (more reliable than context.activity reference)
+		celery_id = getattr(context.request, 'id', 'NO_ID')
 		try:
 			fresh_activity = ScanActivity.objects.get(celery_id=celery_id)
 			
 			# Update the fresh instance
-			fresh_activity.status = self.status
+			fresh_activity.status = context.status
 			fresh_activity.error_message = error_message
-			fresh_activity.traceback = self.traceback
+			fresh_activity.traceback = context.traceback
 			fresh_activity.time = timezone.now()
 			fresh_activity.save()
 			
 			# Update our local reference
-			self.activity = fresh_activity
-			self.activity_id = fresh_activity.id
+			context.activity = fresh_activity
+			context.activity_id = fresh_activity.id
 			
 		except ScanActivity.DoesNotExist:
-			logger.error(f'Task {self.task_name} - No activity found with celery_id {celery_id}')
+			logger.error(f'Task {context.task_name} - No activity found with celery_id {celery_id}')
 		except Exception as e:
-			logger.error(f'Task {self.task_name} - Failed to update activity for celery_id {celery_id}: {e}')
+			logger.error(f'Task {context.task_name} - Failed to update activity for celery_id {celery_id}: {e}')
 			
 		self.notify()
 
 	def notify(self, name=None, severity=None, fields={}, add_meta_info=True):
+		context = self.context
+		if not context:
+			return
+			
 		# Import here to avoid Celery circular import and be able to use `delay`
 		from reNgine.tasks import send_task_notif
 		return send_task_notif.delay(
-			name or self.task_name,
-			status=self.status_str,
-			result=self.result,
-			traceback=self.traceback,
-			output_path=self.output_path,
-			scan_history_id=self.scan_id,
-			engine_id=self.engine_id,
-			subscan_id=self.subscan_id,
+			name or context.task_name,
+			status=context.status_str,
+			result=context.result,
+			traceback=context.traceback,
+			output_path=context.output_path,
+			scan_history_id=context.scan_id,
+			engine_id=context.engine_id,
+			subscan_id=context.subscan_id,
 			severity=severity,
 			add_meta_info=add_meta_info,
 			update_fields=fields)

--- a/web/reNgine/tasks/fuzzing.py
+++ b/web/reNgine/tasks/fuzzing.py
@@ -133,7 +133,7 @@ def dir_file_fuzz(self, ctx={}, description=None):
             # Build final cmd
             fcmd = cmd
             fcmd += f' -x {proxy}' if proxy else ''
-            fcmd += f' -u {url} -json'
+            fcmd += f' -u {url} -s -json'
 
             # Initialize DirectoryScan object
             dirscan = DirectoryScan()


### PR DESCRIPTION
Fix #325 

- Introduces a new TaskContext class to encapsulate and isolate task-specific context, preventing context pollution between concurrent Celery tasks.
- Refactors the RengineTask class to use thread-local storage for context, with properties and methods updated to access data through the new context object.
- Updates task execution, result handling, and activity tracking to operate within the isolated context, improving reliability and maintainability.
- Makes minor adjustment in the fuzzing task to add the -s flag to the command for directory/file fuzzing.