### PR TITLE
fix(api): use scan id instead of object & fix queryset prefetching error

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -2391,14 +2391,26 @@ class EndPointChangesViewSet(viewsets.ModelViewSet):
                     .annotate(
                         change=Value('added', output_field=CharField())
                     )
+                    .prefetch_related(
+                        'subdomain',
+                        'target_domain',
+                        'scan_history',
+                        'techs'
+                    )
                 )
             elif changes == 'removed':
                 queryset = (
                     EndPoint.objects
-                    .filter(scan_history__id=last_scan)
+                    .filter(scan_history__id=last_scan.id)
                     .filter(http_url__in=removed_endpoints)
                     .annotate(
                         change=Value('removed', output_field=CharField())
+                    )
+                    .prefetch_related(
+                        'subdomain',
+                        'target_domain',
+                        'scan_history',
+                        'techs'
                     )
                 )
             else:
@@ -2409,27 +2421,31 @@ class EndPointChangesViewSet(viewsets.ModelViewSet):
                     .annotate(
                         change=Value('added', output_field=CharField())
                     )
+                    .prefetch_related(
+                        'subdomain',
+                        'target_domain',
+                        'scan_history',
+                        'techs'
+                    )
                 )
                 removed_endpoints = (
                     EndPoint.objects
-                    .filter(scan_history__id=last_scan)
+                    .filter(scan_history__id=last_scan.id)
                     .filter(http_url__in=removed_endpoints)
                     .annotate(
                         change=Value('removed', output_field=CharField())
+                    )
+                    .prefetch_related(
+                        'subdomain',
+                        'target_domain',
+                        'scan_history',
+                        'techs'
                     )
                 )
                 queryset = added_endpoint.union(removed_endpoints)
         else:
             # If this is the first scan, return empty queryset as changes are only meaningful from 2nd scan
             queryset = EndPoint.objects.none()
-        
-        # Optimize queries with prefetch_related to avoid N+1 queries
-        queryset = queryset.prefetch_related(
-            'subdomain',
-            'target_domain',
-            'scan_history',
-            'techs'
-        )
         
         return queryset
 


### PR DESCRIPTION
Fix #329 

- Fixes filter usage by referencing last_scan.id instead of last_scan object.
- Moves prefetch_related calls into each queryset branch to fix following error
```
NotSupportedError at /api/listEndPointChanges/
Calling QuerySet.prefetch_related() after union() is not supported.
```
- Ensures prefetching of related fields is applied only to relevant querysets, improving performance and code clarity.