### PR TITLE
chore(docker): update Secator image version in Docker Compose files

### DIFF
--- a/docker/docker-compose.worker.yml
+++ b/docker/docker-compose.worker.yml
@@ -19,7 +19,7 @@ version: '3.8'
 # On ARM64 (aarch64), the Secator image is amd64-only; platform forces amd64 so Docker runs it via QEMU.
 services:
   secator-worker:
-    image: freelabz/secator:latest
+    image: freelabz/secator:0.26.1
     platform: linux/amd64
     container_name: ${SECATOR_WORKER_CONTAINER_NAME:-secator-worker}
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - rengine_network
 
   worker:
-    image: freelabz/secator:latest
+    image: freelabz/secator:0.26.1
     container_name: secator-worker
     restart: unless-stopped
     entrypoint: /entrypoint.sh


### PR DESCRIPTION
- Changed the Secator image version from `latest` to `0.26.1` in both `docker-compose.worker.yml` and `docker-compose.yml` to ensure consistent and predictable deployments.

## Summary by Sourcery

Build:
- Update Secator Docker image tag from latest to 0.26.1 in both main and worker Docker Compose configurations to ensure consistent deployments.